### PR TITLE
Always parameterize when migrating from log4j to slf4j

### DIFF
--- a/src/test/kotlin/org/openrewrite/java/logging/slf4j/ParameterizedLoggingTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/logging/slf4j/ParameterizedLoggingTest.kt
@@ -100,7 +100,43 @@ class ParameterizedLoggingTest : JavaRecipeTest {
     )
 
     @Test
-    fun exceptionArguments() = assertChanged(
+    fun exceptionArgumentsAsConcatenatedString() = assertChanged(
+        before = """
+            import org.slf4j.Logger;
+            import org.slf4j.LoggerFactory;
+
+            class Test {
+                Logger logger = LoggerFactory.getLogger(Test.class);
+
+                void asInteger(String numberString) {
+                    try {
+                        Integer i = Integer.valueOf(numberString);
+                    } catch (NumberFormatException ex) {
+                        logger.debug("some big error: " + ex);
+                    }
+                }
+            }
+        """,
+        after = """
+            import org.slf4j.Logger;
+            import org.slf4j.LoggerFactory;
+
+            class Test {
+                Logger logger = LoggerFactory.getLogger(Test.class);
+
+                void asInteger(String numberString) {
+                    try {
+                        Integer i = Integer.valueOf(numberString);
+                    } catch (NumberFormatException ex) {
+                        logger.debug("some big error: {}", ex);
+                    }
+                }
+            }
+        """
+    )
+
+    @Test
+    fun exceptionArgumentsWithThrowable() = assertChanged(
         before = """
             import org.slf4j.Logger;
             import org.slf4j.LoggerFactory;


### PR DESCRIPTION
When migrating from log4j to slf4j, even in situations such as `logger.info(new Object());`, the migration should be to `logger.info("{}", new Object());` rather than `logger.info(new Object().toString());`. This avoids pitfalls of `toString()`, as well as maintains the benefits of parameterized logging being able to conditionally log based on current log level.

Closes https://github.com/openrewrite/rewrite-logging-frameworks/issues/20