### PR TITLE
Dependency additions and polish for log4j-to-logback recipes

### DIFF
--- a/src/main/resources/META-INF/rewrite/logback.yml
+++ b/src/main/resources/META-INF/rewrite/logback.yml
@@ -17,7 +17,7 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.logging.logback.Log4jToLogback
 displayName: Migrate Log4j to Logback
-description: Migrates Log4j to logback.
+description: Migrates usage of Apache Log4j to using Logback directly. Note, this currently does not modify `log4j.properties` files.
 tags:
   - logging
   - log4j
@@ -25,3 +25,10 @@ tags:
 recipeList:
   - org.openrewrite.java.logging.logback.Log4jAppenderToLogback
   - org.openrewrite.java.logging.logback.Log4jLayoutToLogback
+  - org.openrewrite.maven.AddDependency:
+      groupId: ch.qos.logback
+      artifactId: logback-classic
+      version: 1.x
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.logging.log4j
+      artifactId: log4j-core

--- a/src/test/kotlin/org/openrewrite/java/logging/logback/Log4jAppenderToLogbackTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/logging/logback/Log4jAppenderToLogbackTest.kt
@@ -64,8 +64,7 @@ class Log4jAppenderToLogbackTest : JavaRecipeTest {
                     System.out.println(s);
                 }
             }
-        """,
-        typeValidation = { identifiers = false }
+        """
     )
 
 }

--- a/src/test/kotlin/org/openrewrite/java/logging/logback/Log4jLayoutToLogbackTest.kt
+++ b/src/test/kotlin/org/openrewrite/java/logging/logback/Log4jLayoutToLogbackTest.kt
@@ -64,8 +64,7 @@ class Log4jLayoutToLogbackTest : JavaRecipeTest {
                     return loggingEvent.getMessage();
                 }
             }
-        """,
-        typeValidation = { identifiers = false }
+        """
     )
 
     @Test
@@ -108,7 +107,7 @@ class Log4jLayoutToLogbackTest : JavaRecipeTest {
                 }
             }
         """,
-        typeValidation = { identifiers = false; methodDeclarations = false }
+        typeValidation = { methodDeclarations = false }
     )
 
 }


### PR DESCRIPTION
Remove unnecessary type validation ignores

Use anonymous visitors instead of named static visitors

Improve descriptions on Logback recipes

Maven add dependencys for logback