### PR TITLE
- Update Log4jAppenderToLogback and Log4jLayoutToLogback Java Parsers…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,10 +101,6 @@ dependencies {
     // see https://github.com/gradle/kotlin-dsl-samples/issues/1301 for why (okhttp is leaking parts of kotlin stdlib)
     compileOnly("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
-    runtimeOnly("org.slf4j:slf4j-api:1.+")
-    runtimeOnly("log4j:log4j:1.+")
-    runtimeOnly("org.apache.logging.log4j:log4j-api:2.+")
-
     testImplementation("org.jetbrains.kotlin:kotlin-reflect")
     testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
@@ -120,9 +116,13 @@ dependencies {
     testRuntimeOnly("org.openrewrite:rewrite-java-8:${rewriteVersion}")
 
     testRuntimeOnly("commons-logging:commons-logging:1.2")
-    testRuntimeOnly("ch.qos.logback:logback-classic:1.0.13")
+    testRuntimeOnly("ch.qos.logback:logback-classic:1+")
 
     testRuntimeOnly("org.apache.logging.log4j:log4j-core:2.+")
+    testRuntimeOnly("org.apache.logging.log4j:log4j-api:2.+")
+
+    testRuntimeOnly("org.slf4j:slf4j-api:1.+")
+    testRuntimeOnly("log4j:log4j:1.+")
 }
 
 tasks.withType(KotlinCompile::class.java).configureEach {

--- a/src/main/java/org/openrewrite/java/logging/logback/Log4jAppenderToLogback.java
+++ b/src/main/java/org/openrewrite/java/logging/logback/Log4jAppenderToLogback.java
@@ -79,6 +79,9 @@ public class Log4jAppenderToLogback extends Recipe {
                         cd = cd.withTemplate(
                                 JavaTemplate.builder(this::getCursor, "AppenderBase<ILoggingEvent>")
                                         .imports("ch.qos.logback.core.AppenderBase", "ch.qos.logback.classic.spi.ILoggingEvent")
+                                        .javaParser(() -> JavaParser.fromJavaVersion().dependsOn(
+                                                "package ch.qos.logback.classic.spi;public interface ILoggingEvent{ }",
+                                                "package org.apache.log4j.spi;public class LoggingEvent { public String getRenderedMessage() {return null;}}").build())
                                         .build(),
                                 cd.getCoordinates().replaceExtendsClause()
                         );

--- a/src/main/java/org/openrewrite/java/logging/logback/Log4jLayoutToLogback.java
+++ b/src/main/java/org/openrewrite/java/logging/logback/Log4jLayoutToLogback.java
@@ -68,7 +68,6 @@ public class Log4jLayoutToLogback extends Recipe {
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
                 J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
-
                 if (cd.getExtends() != null && cd.getExtends().getType() != null) {
                     JavaType.FullyQualified fullyQualifiedExtends = TypeUtils.asFullyQualified(cd.getExtends().getType());
                     if (fullyQualifiedExtends != null && "org.apache.log4j.Layout".equals(fullyQualifiedExtends.getFullyQualifiedName())) {
@@ -83,6 +82,9 @@ public class Log4jLayoutToLogback extends Recipe {
                         cd = cd.withTemplate(
                                 JavaTemplate.builder(this::getCursor, "LayoutBase<ILoggingEvent>")
                                         .imports("ch.qos.logback.core.LayoutBase", "ch.qos.logback.classic.spi.ILoggingEvent")
+                                        .javaParser(() -> JavaParser.fromJavaVersion().dependsOn(
+                                                "package ch.qos.logback.classic.spi;public interface ILoggingEvent{ }",
+                                                "package org.apache.log4j.spi;public class LoggingEvent { public String getRenderedMessage() {return null;}}").build())
                                         .build(),
                                 cd.getCoordinates().replaceExtendsClause()
                         );


### PR DESCRIPTION
… with dependency stubs, to fix missing type errors.

- Change Log4j and Slf4j dependency scopes to testRuntimeOnly.