### PR TITLE
Fix: Slf4jLogShouldBeConstant removes passed exception

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstant.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstant.java
@@ -83,7 +83,7 @@ public class Slf4jLogShouldBeConstant extends Recipe {
                         if (STRING_FORMAT.matches(args.get(0))) {
                             J.MethodInvocation stringFormat = (J.MethodInvocation) args.get(0);
 
-                            if (stringFormat.getArguments().size() <= 1 ||
+                            if (stringFormat.getArguments().isEmpty() ||
                                     !CompleteExceptionLogging.isStringLiteral(stringFormat.getArguments().get(0))
                             ) {
                                 return method;

--- a/src/main/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstant.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstant.java
@@ -33,10 +33,15 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Slf4jLogShouldBeConstant extends Recipe {
+
+    private static final Pattern SLF4J_FORMAT_SPECIFIER_PATTERN = Pattern.compile("\\{}");
+    private static final Pattern FORMAT_SPECIFIER_PATTERN = Pattern.compile("%[\\d.]*[dfscbBhHn%]");
+
+    // A regular expression that matches index specifiers like '%2$s', '%1$s', etc.
+    private static final Pattern INDEXED_FORMAT_SPECIFIER_PATTERN = Pattern.compile(".*%(\\d+\\$)[a-zA-Z].*");
     private static final MethodMatcher SLF4J_LOG = new MethodMatcher("org.slf4j.Logger *(..)");
     private static final MethodMatcher STRING_FORMAT = new MethodMatcher("java.lang.String format(..)");
 
@@ -66,6 +71,7 @@ public class Slf4jLogShouldBeConstant extends Recipe {
     public Set<String> getTags() {
         return new HashSet<>(Arrays.asList("logging", "slf4j"));
     }
+
     @Override
     protected JavaVisitor<ExecutionContext> getVisitor() {
         return new JavaVisitor<ExecutionContext>() {
@@ -79,25 +85,27 @@ public class Slf4jLogShouldBeConstant extends Recipe {
                             J.MethodInvocation stringFormat = (J.MethodInvocation) args.get(0);
 
                             if (stringFormat.getArguments() == null ||
-                                stringFormat.getArguments().size() <= 1 ||
-                                !CompleteExceptionLogging.isStringLiteral(stringFormat.getArguments().get(0))
-                                ) {
+                                    stringFormat.getArguments().size() <= 1 ||
+                                    !CompleteExceptionLogging.isStringLiteral(stringFormat.getArguments().get(0))
+                            ) {
                                 return method;
                             }
 
                             String strFormat = ((J.Literal) stringFormat.getArguments().get(0)).getValue().toString();
-                            if (containsIndexFormatSpecifier(strFormat)) {
+                            if (containsIndexFormatSpecifier(strFormat) || containsCombinedFormatSpecifiers(strFormat)) {
                                 return method;
                             }
                             String updatedStrFormat = replaceFormatSpecifier(strFormat, "{}");
-                            return method.withArguments(ListUtils.map(stringFormat.getArguments(), (n, arg) -> {
+                            List<Expression> stringFormatWithArgs = ListUtils.map(stringFormat.getArguments(), (n, arg) -> {
                                 if (n == 0) {
                                     J.Literal str = (J.Literal) arg;
                                     return str.withValue(updatedStrFormat)
-                                        .withValueSource("\"" + updatedStrFormat + "\"");
+                                            .withValueSource("\"" + updatedStrFormat + "\"");
                                 }
                                 return arg;
-                            }));
+                            });
+                            List<Expression> originalArgsWithoutMessage = args.subList(1, args.size());
+                            return method.withArguments(ListUtils.concatAll(stringFormatWithArgs, originalArgsWithoutMessage));
                         } else if (STRING_VALUE_OF.matches(args.get(0))) {
                             Expression valueOf = ((J.MethodInvocation) args.get(0)).getArguments().get(0);
                             if (TypeUtils.isAssignableTo(JavaType.ShallowClass.build("java.lang.Throwable"), valueOf.getType())) {
@@ -120,21 +128,21 @@ public class Slf4jLogShouldBeConstant extends Recipe {
         };
     }
 
+    private boolean containsCombinedFormatSpecifiers(String str) {
+        return FORMAT_SPECIFIER_PATTERN.matcher(str).find() && SLF4J_FORMAT_SPECIFIER_PATTERN.matcher(str).find();
+    }
+
     private static String replaceFormatSpecifier(String str, String replacement) {
         if (str == null || str.isEmpty()) {
             return str;
         }
-        Pattern pattern = Pattern.compile("%[\\d\\.]*[dfscbBhHn%]");
-        Matcher matcher = pattern.matcher(str);
-        return matcher.replaceAll(replacement);
+        return FORMAT_SPECIFIER_PATTERN.matcher(str).replaceAll(replacement);
     }
 
     private static boolean containsIndexFormatSpecifier(String str) {
         if (str == null || str.isEmpty()) {
             return false;
         }
-        // A regular expression that matches index specifiers like '%2$s', '%1$s', etc.
-        String indexSpecifierRegex = ".*%(\\d+\\$)[a-zA-Z].*";
-        return str.matches(indexSpecifierRegex);
+        return INDEXED_FORMAT_SPECIFIER_PATTERN.matcher(str).find();
     }
 }

--- a/src/main/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstant.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstant.java
@@ -83,9 +83,7 @@ public class Slf4jLogShouldBeConstant extends Recipe {
                         if (STRING_FORMAT.matches(args.get(0))) {
                             J.MethodInvocation stringFormat = (J.MethodInvocation) args.get(0);
 
-                            if (stringFormat.getArguments().isEmpty() ||
-                                    !CompleteExceptionLogging.isStringLiteral(stringFormat.getArguments().get(0))
-                            ) {
+                            if (!CompleteExceptionLogging.isStringLiteral(stringFormat.getArguments().get(0))) {
                                 return method;
                             }
 

--- a/src/main/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstant.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstant.java
@@ -30,10 +30,7 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Pattern;
 
 public class Slf4jLogShouldBeConstant extends Recipe {
@@ -92,8 +89,8 @@ public class Slf4jLogShouldBeConstant extends Recipe {
                                 return method;
                             }
 
-                            String strFormat = String.valueOf(((J.Literal) stringFormat.getArguments().get(0)).getValue());
-                            if (StringUtils.isBlank(strFormat) || containsIndexFormatSpecifier(strFormat) || containsCombinedFormatSpecifiers(strFormat)) {
+                            String strFormat = Objects.requireNonNull(((J.Literal) stringFormat.getArguments().get(0)).getValue()).toString();
+                            if (containsIndexFormatSpecifier(strFormat) || containsCombinedFormatSpecifiers(strFormat)) {
                                 return method;
                             }
                             String updatedStrFormat = replaceFormatSpecifier(strFormat, SLF4J_FORMAT_SPECIFIER);

--- a/src/main/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstant.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstant.java
@@ -41,7 +41,7 @@ public class Slf4jLogShouldBeConstant extends Recipe {
     private static final Pattern FORMAT_SPECIFIER_PATTERN = Pattern.compile("%[\\d.]*[dfscbBhHn%]");
 
     // A regular expression that matches index specifiers like '%2$s', '%1$s', etc.
-    private static final Pattern INDEXED_FORMAT_SPECIFIER_PATTERN = Pattern.compile(".*%(\\d+\\$)[a-zA-Z].*");
+    private static final Pattern INDEXED_FORMAT_SPECIFIER_PATTERN = Pattern.compile("%(\\d+\\$)[a-zA-Z]");
     private static final MethodMatcher SLF4J_LOG = new MethodMatcher("org.slf4j.Logger *(..)");
     private static final MethodMatcher STRING_FORMAT = new MethodMatcher("java.lang.String format(..)");
 

--- a/src/test/java/org/openrewrite/java/logging/slf4j/CompleteExceptionLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/CompleteExceptionLoggingTest.java
@@ -16,7 +16,7 @@
 package org.openrewrite.java.logging.slf4j;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.internal.DocumentExample;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;

--- a/src/test/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstantTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstantTest.java
@@ -267,6 +267,7 @@ class Slf4jLogShouldBeConstantTest implements RewriteTest {
           )
         );
     }
+
     @Test
     void doNotUseStringFormatForBlankLog() {
         //language=java

--- a/src/test/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstantTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstantTest.java
@@ -240,4 +240,57 @@ class Slf4jLogShouldBeConstantTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doNotUseStringFormatWithoutArgs() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.slf4j.Logger;
+              class A {
+                  Logger log;
+                  void method() {
+                      log.info(String.format("hi"));
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+              class A {
+                  Logger log;
+                  void method() {
+                      log.info("hi");
+                  }
+              }
+              """
+          )
+        );
+    }
+    @Test
+    void doNotUseStringFormatForBlankLog() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.slf4j.Logger;
+              class A {
+                  Logger log;
+                  void method() {
+                      log.info(String.format("    "));
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+              class A {
+                  Logger log;
+                  void method() {
+                      log.info("    ");
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstantTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstantTest.java
@@ -39,13 +39,10 @@ class Slf4jLogShouldBeConstantTest implements RewriteTest {
           java(
             """
               import org.slf4j.Logger;
-              import org.slf4j.LoggerFactory;
-
               class A {
-                  private final static Logger LOG = LoggerFactory.getLogger(A.class);
-
+                  Logger log;
                   public void inconsistent(String message, Object... args) {
-                      LOG.warn(String.format(message, args));
+                      log.warn(String.format(message, args));
                   }
               }
               """
@@ -61,25 +58,23 @@ class Slf4jLogShouldBeConstantTest implements RewriteTest {
           java(
             """
               import org.slf4j.Logger;
-              import org.slf4j.LoggerFactory;
               class Test {
-                  private final static Logger LOG = LoggerFactory.getLogger(Test.class);
+                  Logger log;
                   void test() {
                       Object obj1 = new Object();
                       Object obj2 = new Object();
-                      LOG.info(String.format("Object 1 is %s and Object 2 is %s", obj1, obj2));
+                      log.info(String.format("Object 1 is %s and Object 2 is %s", obj1, obj2));
                   }
               }
               """,
             """
               import org.slf4j.Logger;
-              import org.slf4j.LoggerFactory;
               class Test {
-                  private final static Logger LOG = LoggerFactory.getLogger(Test.class);
+                  Logger log;
                   void test() {
                       Object obj1 = new Object();
                       Object obj2 = new Object();
-                      LOG.info("Object 1 is {} and Object 2 is {}", obj1, obj2);
+                      log.info("Object 1 is {} and Object 2 is {}", obj1, obj2);
                   }
               }
               """
@@ -95,26 +90,24 @@ class Slf4jLogShouldBeConstantTest implements RewriteTest {
           java(
             """
               import org.slf4j.Logger;
-              import org.slf4j.LoggerFactory;
               class Test {
-                  private final static Logger LOG = LoggerFactory.getLogger(Test.class);
+                  Logger log;
                   void test() {
                       try {
                       } catch(Exception e) {
-                          LOG.warn(String.valueOf(e));
+                          log.warn(String.valueOf(e));
                       }
                   }
               }
               """,
             """
               import org.slf4j.Logger;
-              import org.slf4j.LoggerFactory;
               class Test {
-                  private final static Logger LOG = LoggerFactory.getLogger(Test.class);
+                  Logger log;
                   void test() {
                       try {
                       } catch(Exception e) {
-                          LOG.warn("Exception", e);
+                          log.warn("Exception", e);
                       }
                   }
               }
@@ -131,23 +124,21 @@ class Slf4jLogShouldBeConstantTest implements RewriteTest {
           java(
             """
               import org.slf4j.Logger;
-              import org.slf4j.LoggerFactory;
               class Test {
-                  private final static Logger LOG = LoggerFactory.getLogger(Test.class);
+                  Logger log;
                   void test() {
                       Object obj1 = new Object();
-                      LOG.info(obj1.toString());
+                      log.info(obj1.toString());
                   }
               }
               """,
             """
               import org.slf4j.Logger;
-              import org.slf4j.LoggerFactory;
               class Test {
-                  private final static Logger LOG = LoggerFactory.getLogger(Test.class);
+                  Logger log;
                   void test() {
                       Object obj1 = new Object();
-                      LOG.info("{}", obj1);
+                      log.info("{}", obj1);
                   }
               }
               """
@@ -162,11 +153,10 @@ class Slf4jLogShouldBeConstantTest implements RewriteTest {
           java(
             """
               import org.slf4j.Logger;
-              import org.slf4j.LoggerFactory;
               class A {
-                  private final static Logger LOG = LoggerFactory.getLogger(A.class);
+                  Logger log;
                   void method() {
-                      LOG.info(String.format("The the second argument is '%2$s', and the first argument is '%1$s'.", "foo", "bar"));
+                      log.info(String.format("The the second argument is '%2$s', and the first argument is '%1$s'.", "foo", "bar"));
                   }
               }
               """
@@ -181,25 +171,19 @@ class Slf4jLogShouldBeConstantTest implements RewriteTest {
           java(
             """
               import org.slf4j.Logger;
-              import org.slf4j.LoggerFactory;
-
               class A {
-                  private final static Logger LOG = LoggerFactory.getLogger(A.class);
-
+                  Logger log;
                   void method() {
-                      LOG.info(String.format("The first argument is '%d', and the second argument is '%.2f'.", 1, 2.3333));
+                      log.info(String.format("The first argument is '%d', and the second argument is '%.2f'.", 1, 2.3333));
                   }
               }
               """,
             """
               import org.slf4j.Logger;
-              import org.slf4j.LoggerFactory;
-
               class A {
-                  private final static Logger LOG = LoggerFactory.getLogger(A.class);
-
+                  Logger log;
                   void method() {
-                      LOG.info("The first argument is '{}', and the second argument is '{}'.", 1, 2.3333);
+                      log.info("The first argument is '{}', and the second argument is '{}'.", 1, 2.3333);
                   }
               }
               """
@@ -215,27 +199,21 @@ class Slf4jLogShouldBeConstantTest implements RewriteTest {
           java(
             """
               import org.slf4j.Logger;
-              import org.slf4j.LoggerFactory;
-
               class A {
-                  private final static Logger LOG = LoggerFactory.getLogger(A.class);
-
+                  Logger log;
                   void method() {
                       Exception ex = new Exception();
-                      LOG.warn(String.format("Unexpected exception: %s", ex.getClass().getName()), ex);
+                      log.warn(String.format("Unexpected exception: %s", ex.getClass().getName()), ex);
                   }
               }
               """,
             """
               import org.slf4j.Logger;
-              import org.slf4j.LoggerFactory;
-
               class A {
-                  private final static Logger LOG = LoggerFactory.getLogger(A.class);
-
+                  Logger log;
                   void method() {
                       Exception ex = new Exception();
-                      LOG.warn("Unexpected exception: {}", ex.getClass().getName(), ex);
+                      log.warn("Unexpected exception: {}", ex.getClass().getName(), ex);
                   }
               }
               """
@@ -251,14 +229,11 @@ class Slf4jLogShouldBeConstantTest implements RewriteTest {
           java(
             """
               import org.slf4j.Logger;
-              import org.slf4j.LoggerFactory;
-
               class A {
-                  private final static Logger LOG = LoggerFactory.getLogger(A.class);
-
+                  Logger log;
                   void method() {
                       Exception ex = new Exception();
-                      LOG.warn(String.format("Message: {} from Unexpected exception: %s", ex.getClass().getName()), ex.getMessage(), ex);
+                      log.warn(String.format("Message: {} from Unexpected exception: %s", ex.getClass().getName()), ex.getMessage(), ex);
                   }
               }
               """


### PR DESCRIPTION
fixes: https://github.com/openrewrite/rewrite-logging-frameworks/issues/95

- Add remaining arguments at the end of the log method call
- Ignore log calls where specifiers like %s and {} are combined as order might be an issue.
- improve consistency in tests
- Extract Pattern from method invocation to improve performance