### PR TITLE
Fix: Loggers should be named for their enclosing classes should not replace calls to getClass()

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/slf4j/LoggersNamedForEnclosingClass.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/LoggersNamedForEnclosingClass.java
@@ -91,6 +91,12 @@ public class LoggersNamedForEnclosingClass extends Recipe {
                     }
                 }
 
+                if(mi.getArguments().get(0) instanceof J.MethodInvocation &&
+                        ((J.MethodInvocation)mi.getArguments().get(0)).getName().toString().equals("getClass") &&
+                        firstEnclosingClass.hasModifier(J.Modifier.Type.Abstract)){
+                    return mi;
+                }
+
                 return mi.withTemplate(JavaTemplate.builder(this::getCursor, "LoggerFactory.getLogger(#{})")
                         .javaParser(() -> JavaParser.fromJavaVersion().classpath("slf4j-api").build())
                         .build(),

--- a/src/main/java/org/openrewrite/java/logging/slf4j/LoggersNamedForEnclosingClass.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/LoggersNamedForEnclosingClass.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.logging.slf4j;
 
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -93,7 +92,7 @@ public class LoggersNamedForEnclosingClass extends Recipe {
 
                 if(mi.getArguments().get(0) instanceof J.MethodInvocation &&
                         ((J.MethodInvocation)mi.getArguments().get(0)).getName().toString().equals("getClass") &&
-                        firstEnclosingClass.hasModifier(J.Modifier.Type.Abstract)){
+                        !firstEnclosingClass.hasModifier(J.Modifier.Type.Final)){
                     return mi;
                 }
 

--- a/src/test/java/org/openrewrite/java/logging/slf4j/CompleteExceptionLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/CompleteExceptionLoggingTest.java
@@ -16,7 +16,7 @@
 package org.openrewrite.java.logging.slf4j;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.internal.DocumentExample;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;

--- a/src/test/java/org/openrewrite/java/logging/slf4j/LoggersNamedForEnclosingClassTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/LoggersNamedForEnclosingClassTest.java
@@ -60,7 +60,7 @@ class LoggersNamedForEnclosingClassTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/69")
     @Test
-    void shouldRenameLoggerFromMethodInvocationToClass() {
+    void shouldRenameLoggerFromMethodInvocationToClassForNonAbstractClass() {
         //language=java
         rewriteRun(
           java(
@@ -85,7 +85,7 @@ class LoggersNamedForEnclosingClassTest implements RewriteTest {
     }
 
     @Test
-    void shouldNotChangeCorrectLoggername() {
+    void shouldNotChangeCorrectLoggerName() {
         //language=java
         rewriteRun(
           java(
@@ -102,6 +102,7 @@ class LoggersNamedForEnclosingClassTest implements RewriteTest {
 
     @Test
     void doNotChangeJavaDoc() {
+        //language=java
         rewriteRun(
           java(
             """
@@ -114,6 +115,24 @@ class LoggersNamedForEnclosingClassTest implements RewriteTest {
                    */
                   void method() {
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/101")
+    @Test
+    void doNotChangeGetClassOnAbstractClass(){
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.slf4j.Logger;
+              import org.slf4j.LoggerFactory;
+              class WrongClass {}
+              abstract class A {
+                  private Logger logger = LoggerFactory.getLogger(getClass());
               }
               """
           )

--- a/src/test/java/org/openrewrite/java/logging/slf4j/LoggersNamedForEnclosingClassTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/LoggersNamedForEnclosingClassTest.java
@@ -60,7 +60,7 @@ class LoggersNamedForEnclosingClassTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/69")
     @Test
-    void shouldRenameLoggerFromMethodInvocationToClassForNonAbstractClass() {
+    void shouldRenameLoggerFromMethodInvocationToClassForFinalClass() {
         //language=java
         rewriteRun(
           java(
@@ -68,7 +68,7 @@ class LoggersNamedForEnclosingClassTest implements RewriteTest {
               import org.slf4j.Logger;
               import org.slf4j.LoggerFactory;
               class WrongClass {}
-              class A {
+              final class A {
                   private Logger logger = LoggerFactory.getLogger(getClass());
               }
               """,
@@ -76,7 +76,7 @@ class LoggersNamedForEnclosingClassTest implements RewriteTest {
               import org.slf4j.Logger;
               import org.slf4j.LoggerFactory;
               class WrongClass {}
-              class A {
+              final class A {
                   private Logger logger = LoggerFactory.getLogger(A.class);
               }
               """
@@ -123,7 +123,7 @@ class LoggersNamedForEnclosingClassTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/101")
     @Test
-    void doNotChangeGetClassOnAbstractClass(){
+    void doNotChangeGetClassOnNonFinalClass(){
         //language=java
         rewriteRun(
           java(
@@ -131,7 +131,7 @@ class LoggersNamedForEnclosingClassTest implements RewriteTest {
               import org.slf4j.Logger;
               import org.slf4j.LoggerFactory;
               class WrongClass {}
-              abstract class A {
+              class A {
                   private Logger logger = LoggerFactory.getLogger(getClass());
               }
               """

--- a/src/test/java/org/openrewrite/java/logging/slf4j/LoggersNamedForEnclosingClassTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/LoggersNamedForEnclosingClassTest.java
@@ -43,7 +43,7 @@ class LoggersNamedForEnclosingClassTest implements RewriteTest {
               import org.slf4j.LoggerFactory;
               class WrongClass {}
               class A {
-                  private final static Logger LOG = LoggerFactory.getLogger(WrongClass.class);
+                  Logger log = LoggerFactory.getLogger(WrongClass.class);
               }
               """,
             """
@@ -51,7 +51,7 @@ class LoggersNamedForEnclosingClassTest implements RewriteTest {
               import org.slf4j.LoggerFactory;
               class WrongClass {}
               class A {
-                  private final static Logger LOG = LoggerFactory.getLogger(A.class);
+                  Logger log = LoggerFactory.getLogger(A.class);
               }
               """
           )
@@ -67,17 +67,15 @@ class LoggersNamedForEnclosingClassTest implements RewriteTest {
             """
               import org.slf4j.Logger;
               import org.slf4j.LoggerFactory;
-              class WrongClass {}
               final class A {
-                  private Logger logger = LoggerFactory.getLogger(getClass());
+                  Logger log = LoggerFactory.getLogger(getClass());
               }
               """,
             """
               import org.slf4j.Logger;
               import org.slf4j.LoggerFactory;
-              class WrongClass {}
               final class A {
-                  private Logger logger = LoggerFactory.getLogger(A.class);
+                  Logger log = LoggerFactory.getLogger(A.class);
               }
               """
           )
@@ -93,7 +91,7 @@ class LoggersNamedForEnclosingClassTest implements RewriteTest {
               import org.slf4j.Logger;
               import org.slf4j.LoggerFactory;
               class A {
-                  private final static Logger LOG = LoggerFactory.getLogger(A.class);
+                  Logger log = LoggerFactory.getLogger(A.class);
               }
               """
           )
@@ -130,9 +128,8 @@ class LoggersNamedForEnclosingClassTest implements RewriteTest {
             """
               import org.slf4j.Logger;
               import org.slf4j.LoggerFactory;
-              class WrongClass {}
               class A {
-                  private Logger logger = LoggerFactory.getLogger(getClass());
+                  Logger log = LoggerFactory.getLogger(getClass());
               }
               """
           )


### PR DESCRIPTION
fixes: https://github.com/openrewrite/rewrite-logging-frameworks/issues/101

Do not remove `getClass()` when creating logger if the enclosing class is abstract