### PR TITLE
Support for Lombok log annotations in three recipes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite:rewrite-java-tck")
 
+    testImplementation("org.projectlombok:lombok:latest.release")
     testImplementation("org.assertj:assertj-core:latest.release")
 
     testRuntimeOnly("org.openrewrite:rewrite-java-17")

--- a/src/main/java/org/openrewrite/java/logging/PrintStackTraceToLogError.java
+++ b/src/main/java/org/openrewrite/java/logging/PrintStackTraceToLogError.java
@@ -17,16 +17,22 @@ package org.openrewrite.java.logging;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.jetbrains.annotations.NotNull;
 import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.FindFieldsOfType;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Set;
+import java.util.UUID;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -69,6 +75,7 @@ public class PrintStackTraceToLogError extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         MethodMatcher printStackTrace = new MethodMatcher("java.lang.Throwable printStackTrace(..)");
         LoggingFramework framework = LoggingFramework.fromOption(loggingFramework);
+        AnnotationMatcher lombokLogAnnotationMatcher = new AnnotationMatcher("@lombok.extern..*");
 
         JavaIsoVisitor<ExecutionContext> visitor = new JavaIsoVisitor<ExecutionContext>() {
             @Override
@@ -78,23 +85,36 @@ public class PrintStackTraceToLogError extends Recipe {
                     J.ClassDeclaration clazz = getCursor().firstEnclosingOrThrow(J.ClassDeclaration.class);
                     Set<J.VariableDeclarations> loggers = FindFieldsOfType.find(clazz, framework.getLoggerType());
                     if (!loggers.isEmpty()) {
-                        m = framework.getErrorTemplate(this, "\"Exception\"")
-                                .apply(
-                                        new Cursor(getCursor().getParent(), m),
-                                        m.getCoordinates().replace(),
-                                        loggers.iterator().next().getVariables().get(0).getName(),
-                                        m.getSelect());
-                        if (framework == LoggingFramework.JUL) {
-                            maybeAddImport("java.util.logging.Level");
-                        }
+                        J.Identifier logField = loggers.iterator().next().getVariables().get(0).getName();
+                        m = replaceMethodInvocation(m, logField);
+                    } else if (clazz.getAllAnnotations().stream().anyMatch(lombokLogAnnotationMatcher::matches)) {
+                        String fieldName = loggerName == null ? "log" : loggerName;
+                        J.Identifier logField = new J.Identifier(UUID.randomUUID(), Space.SINGLE_SPACE, Markers.EMPTY, Collections.emptyList(), fieldName, null, null);
+                        m = replaceMethodInvocation(m, logField);
                     } else if (addLogger != null && addLogger) {
                         doAfterVisit(AddLogger.addLogger(clazz, framework, loggerName == null ? "logger" : loggerName));
                     }
                 }
                 return m;
             }
-        };
 
-        return addLogger != null && addLogger ? visitor : Preconditions.check(new UsesType<>(framework.getLoggerType(), null), visitor);
+            @NotNull
+            private J.MethodInvocation replaceMethodInvocation(J.MethodInvocation m, J.Identifier logField) {
+                if (framework == LoggingFramework.JUL) {
+                    maybeAddImport("java.util.logging.Level");
+                }
+                return framework.getErrorTemplate(this, "\"Exception\"").apply(
+                        new Cursor(getCursor().getParent(), m),
+                        m.getCoordinates().replace(),
+                        logField,
+                        m.getSelect());
+            }
+
+        };
+        return addLogger != null && addLogger ? visitor : Preconditions.check(
+                Preconditions.or(
+                        new UsesType<>(framework.getLoggerType(), null),
+                        new UsesType<>("lombok.extern..*", null))
+                , visitor);
     }
 }

--- a/src/main/java/org/openrewrite/java/logging/PrintStackTraceToLogError.java
+++ b/src/main/java/org/openrewrite/java/logging/PrintStackTraceToLogError.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.logging;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.jetbrains.annotations.NotNull;
 import org.openrewrite.*;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.AnnotationMatcher;
@@ -98,7 +97,6 @@ public class PrintStackTraceToLogError extends Recipe {
                 return m;
             }
 
-            @NotNull
             private J.MethodInvocation replaceMethodInvocation(J.MethodInvocation m, J.Identifier logField) {
                 if (framework == LoggingFramework.JUL) {
                     maybeAddImport("java.util.logging.Level");
@@ -109,7 +107,6 @@ public class PrintStackTraceToLogError extends Recipe {
                         logField,
                         m.getSelect());
             }
-
         };
         return addLogger != null && addLogger ? visitor : Preconditions.check(
                 Preconditions.or(

--- a/src/test/java/org/openrewrite/java/logging/SystemErrToLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/SystemErrToLoggingTest.java
@@ -179,7 +179,6 @@ class SystemErrToLoggingTest implements RewriteTest {
               @Slf4j
               class Test {
                   int n;
-                  Logger logger;
                   
                   void test() {
                       try {
@@ -195,7 +194,6 @@ class SystemErrToLoggingTest implements RewriteTest {
               @Slf4j
               class Test {
                   int n;
-                  Logger logger;
                   
                   void test() {
                       try {

--- a/src/test/java/org/openrewrite/java/logging/log4j/Log4j1ToLog4j2Test.java
+++ b/src/test/java/org/openrewrite/java/logging/log4j/Log4j1ToLog4j2Test.java
@@ -21,12 +21,15 @@ import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-import org.openrewrite.xml.tree.Xml;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.mavenProject;
 import static org.openrewrite.java.Assertions.srcMainJava;
 import static org.openrewrite.maven.Assertions.pomXml;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class Log4j1ToLog4j2Test implements RewriteTest {
 
@@ -163,7 +166,11 @@ class Log4j1ToLog4j2Test implements RewriteTest {
                           </dependencies>
                       </project>
                   """,
-                """
+                sourceSpecs -> sourceSpecs.after(after -> {
+                    Matcher matcher = Pattern.compile("<version>(2\\.2\\d\\.\\d)</version>").matcher(after);
+                    assertTrue(matcher.find());
+                    String version = matcher.group(1);
+                    return """
                       <project>
                           <groupId>com.mycompany.app</groupId>
                           <artifactId>my-app</artifactId>
@@ -177,21 +184,22 @@ class Log4j1ToLog4j2Test implements RewriteTest {
                               <dependency>
                                   <groupId>org.apache.logging.log4j</groupId>
                                   <artifactId>log4j-api</artifactId>
-                                  <version>2.20.0</version>
+                                  <version>%1$s</version>
                               </dependency>
                               <dependency>
                                   <groupId>org.apache.logging.log4j</groupId>
                                   <artifactId>log4j-core</artifactId>
-                                  <version>2.20.0</version>
+                                  <version>%1$s</version>
                               </dependency>
                               <dependency>
                                   <groupId>org.apache.logging.log4j</groupId>
                                   <artifactId>log4j-slf4j-impl</artifactId>
-                                  <version>2.20.0</version>
+                                  <version>%1$s</version>
                               </dependency>
                           </dependencies>
                       </project>
-                  """
+                  """.formatted(version);
+                })
               )
             )
           )


### PR DESCRIPTION
## What's changed?
Detect for instance `@Slf4j` in recipes that move away from `System.out`, `System.err` and `printStackTrace`.

## What's your motivation?
Fixes https://github.com/openrewrite/rewrite-logging-frameworks/issues/114

## Anything in particular you'd like reviewers to focus on?
Should we cover more recipes already?

## Have you considered any alternatives or workarounds?
We could have generically fixed this by adding synthetic log fields to the associated classes, but I figured that's harder to do for a quick win here.

## Any additional context
- https://github.com/openrewrite/rewrite/issues/1297
