### PR TITLE
do not modify when not Object::toString()

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstant.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstant.java
@@ -51,6 +51,7 @@ public class Slf4jLogShouldBeConstant extends Recipe {
     }
 
     private static final MethodMatcher STRING_VALUE_OF = new MethodMatcher("java.lang.String valueOf(..)");
+    private static final MethodMatcher OBJECT_TO_STRING = new MethodMatcher("java.lang.Object toString()");
 
     @Override
     public String getDisplayName() {
@@ -106,11 +107,11 @@ public class Slf4jLogShouldBeConstant extends Recipe {
                                 m = m.withSelect(method.getSelect());
                                 return m;
                             }
-                        } else if (args.get(0) instanceof J.MethodInvocation && "toString".equals(((J.MethodInvocation) args.get(0)).getSimpleName())) {
-                            Expression valueOf = ((J.MethodInvocation) args.get(0)).getSelect();
-                            if (valueOf != null) {
+                        } else if (OBJECT_TO_STRING.matches(args.get(0))) {
+                            Expression toString = ((J.MethodInvocation) args.get(0)).getSelect();
+                            if (toString != null) {
                                 J.MethodInvocation m = JavaTemplate.builder("\"{}\", #{any()}").contextSensitive().build()
-                                        .apply(getCursor(), method.getCoordinates().replaceArguments(), valueOf);
+                                        .apply(getCursor(), method.getCoordinates().replaceArguments(), toString);
                                 m = m.withSelect(method.getSelect());
                                 return m;
                             }

--- a/src/test/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstantTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstantTest.java
@@ -155,7 +155,7 @@ class Slf4jLogShouldBeConstantTest implements RewriteTest {
           java("""
             import org.slf4j.Logger;
             import org.slf4j.LoggerFactory;
-            class A implements Cloneable {
+            class A {
                 private static final Logger log = LoggerFactory.getLogger(A.class);
             
                 public void foo() {
@@ -309,6 +309,54 @@ class Slf4jLogShouldBeConstantTest implements RewriteTest {
                   Logger log;
                   void method() {
                       log.info("    ");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void notObjectToString() {
+        //language=java
+        rewriteRun(
+          java("""
+            import org.slf4j.Logger;
+            import org.slf4j.LoggerFactory;
+            import java.util.Arrays;
+            class A {
+                private static final Logger log = LoggerFactory.getLogger(A.class);
+                String[] values = new String[]{"test1", "test2"};
+                public void foo() {
+                    log.error(Arrays.toString(values));
+                }
+            }
+            """)
+        );
+    }
+
+    @Test
+    void doNotUseToStringOnAnyClass() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.slf4j.Logger;
+              class Test {
+                  Logger log;
+                  void test() {
+                      Test t = new Test();
+                      log.info(t.toString());
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+              class Test {
+                  Logger log;
+                  void test() {
+                      Test t = new Test();
+                      log.info("{}", t);
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
Added a `MethodMatcher` for `Object::toString()` instead of checking simple name, to avoid matching on other methods called `toString` (like `Arrays.toString(values)`)

## What's your motivation?
Fixes https://github.com/moderneinc/support-app/issues/21

## Anyone you would like to review specifically?
@knutwannheden @timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
