### PR TITLE
Escape dollar sign on messages

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/ParameterizedLogging.java
+++ b/src/main/java/org/openrewrite/java/logging/ParameterizedLogging.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.internal.lang.NonNull;
 import org.openrewrite.internal.lang.Nullable;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
@@ -91,14 +92,14 @@ public class ParameterizedLogging extends Recipe {
                         });
                         messageBuilder.append("\"");
                         newArgList.forEach(arg -> messageBuilder.append(", #{any()}"));
-                        m = JavaTemplate.builder(messageBuilder.toString())
+                        m = JavaTemplate.builder(escapeDollarSign(messageBuilder.toString()))
                                 .contextSensitive()
                                 .build()
                                 .apply(new Cursor(getCursor().getParent(), m), m.getCoordinates().replaceArguments(), newArgList.toArray());
                     } else if (!TypeUtils.isString(logMsg.getType()) && logMsg.getType() instanceof JavaType.Class) {
                         StringBuilder messageBuilder = new StringBuilder("\"{}\"");
                         m.getArguments().forEach(arg -> messageBuilder.append(", #{any()}"));
-                        m = JavaTemplate.builder(messageBuilder.toString())
+                        m = JavaTemplate.builder(escapeDollarSign(messageBuilder.toString()))
                                 .contextSensitive()
                                 .build()
                                 .apply(new Cursor(getCursor().getParent(), m), m.getCoordinates().replaceArguments(), m.getArguments().toArray());
@@ -181,5 +182,9 @@ public class ParameterizedLogging extends Recipe {
                 .getValueSource()
                 .substring(1, literal.getValueSource().length() - 1)
                 .replace("\\", "\\\\");
+    }
+
+    private static String escapeDollarSign(@NonNull String value) {
+        return value.replaceAll("\\$", "\\\\\\$");
     }
 }

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -506,4 +506,60 @@ class ParameterizedLoggingTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void logMethodWithDollarSign() {
+        rewriteRun(
+          spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger info(..)", false)),
+          //language=java
+          java(
+            """
+              import org.slf4j.Logger;
+
+              class Test {
+                  static void method(Logger logger, String name) {
+                      logger.info("This is a message for " + name + " with a $ dollar sign");
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+
+              class Test {
+                  static void method(Logger logger, String name) {
+                      logger.info("This is a message for {} with a $ dollar sign", name);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void logMethodWithCurlyBracketsLiteral() {
+        rewriteRun(
+          spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger info(..)", false)),
+          //language=java
+          java(
+            """
+              import org.slf4j.Logger;
+
+              class Test {
+                  static void method(Logger logger, String name) {
+                      logger.info("This is a message for " + name + " with a curly bracket constant: ${exception}");
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+
+              class Test {
+                  static void method(Logger logger, String name) {
+                      logger.info("This is a message for {} with a curly bracket constant: ${exception}", name);
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Log messages with a dollar sign ($) fails to parse on the `ParameterizedLogging` recipe.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
Disable the recipe and refactor the code manually

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've added the license header to any new files through `./gradlew licenseFormat`
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
