### PR TITLE
Replace Lombok logging annotations when switching frameworks

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/ChangeLombokLogAnnotation.java
+++ b/src/main/java/org/openrewrite/java/logging/ChangeLombokLogAnnotation.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.logging;
+
+import lombok.AllArgsConstructor;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.ChangeType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@AllArgsConstructor
+public class ChangeLombokLogAnnotation extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Replace any Lombok log annotations with target logging framework annotation";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace Lombok annotations such as `@CommonsLog` and `@Log4j` with the target logging framework annotation, or `@Sl4fj` if not provided.";
+    }
+
+    @Option(displayName = "Logging framework",
+            description = "The logging framework to use.",
+            valid = {"SLF4J", "Log4J1", "Log4J2", "JUL", "COMMONS"},
+            required = false)
+    @Nullable
+    private String loggingFramework;
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        String targetLogAnnotationType = getTargetAnnotationType(loggingFramework);
+        return Stream.of(
+                        "lombok.extern.java.Log",
+                        "lombok.extern.apachecommons.CommonsLog",
+                        "lombok.extern.flogger.Flogger",
+                        "lombok.extern.jbosslog.JBossLog",
+                        "lombok.extern.log4j.Log4j",
+                        "lombok.extern.log4j.Log4j2",
+                        "lombok.extern.slf4j.Slf4j",
+                        "lombok.extern.slf4j.XSlf4j",
+                        "lombok.CustomLog")
+                .filter(annotationType -> !annotationType.equals(targetLogAnnotationType))
+                .map(annotationType -> new ChangeType(annotationType, targetLogAnnotationType, true))
+                .collect(Collectors.toList());
+    }
+
+    private static String getTargetAnnotationType(@Nullable String loggingFramework) {
+        if (loggingFramework != null) {
+            switch (LoggingFramework.fromOption(loggingFramework)) {
+                case Log4J1:
+                    return "lombok.extern.log4j.Log4j";
+                case Log4J2:
+                    return "lombok.extern.log4j.Log4j2";
+                case JUL:
+                    return "lombok.extern.java.Log";
+                case COMMONS:
+                    return "lombok.extern.apachecommons.CommonsLog";
+            }
+        }
+        return "lombok.extern.slf4j.Slf4j";
+    }
+}

--- a/src/main/resources/META-INF/rewrite/log4j.yml
+++ b/src/main/resources/META-INF/rewrite/log4j.yml
@@ -62,6 +62,8 @@ tags:
   - logging
   - log4j
 recipeList:
+  - org.openrewrite.java.logging.ChangeLombokLogAnnotation:
+      loggingFramework: Log4J2
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.log4j
       newPackageName: org.apache.logging.log4j

--- a/src/main/resources/META-INF/rewrite/slf4j.yml
+++ b/src/main/resources/META-INF/rewrite/slf4j.yml
@@ -107,6 +107,7 @@ recipeList:
       oldFullyQualifiedTypeName: org.apache.logging.log4j.Logger
       newFullyQualifiedTypeName: org.slf4j.Logger
   - org.openrewrite.java.logging.slf4j.ParameterizedLogging
+  - org.openrewrite.java.logging.ChangeLombokLogAnnotation
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.logging.slf4j.Log4j1ToSlf4j1
@@ -166,3 +167,4 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.commons.logging.Log
       newFullyQualifiedTypeName: org.slf4j.Logger
+  - org.openrewrite.java.logging.ChangeLombokLogAnnotation

--- a/src/test/java/org/openrewrite/java/logging/slf4j/CommonsLoggingToSlf4j1Test.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/CommonsLoggingToSlf4j1Test.java
@@ -34,7 +34,7 @@ class CommonsLoggingToSlf4j1Test implements RewriteTest {
             .scanRuntimeClasspath("org.openrewrite.java.logging")
             .build()
             .activateRecipes("org.openrewrite.java.logging.slf4j.CommonsLogging1ToSlf4j1"))
-          .parser(JavaParser.fromJavaVersion().classpath("commons-logging", "slf4j-api"));
+          .parser(JavaParser.fromJavaVersion().classpath("commons-logging", "slf4j-api", "lombok"));
     }
 
     @DocumentExample
@@ -124,6 +124,36 @@ class CommonsLoggingToSlf4j1Test implements RewriteTest {
                       if (logger.isErrorEnabled()) {
                           logger.error("uh oh");
                       }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeLombokLogAnnotation() {
+        //language=java
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.builder().identifiers(false).methodInvocations(false).build()),
+          java(
+            """
+              import lombok.extern.apachecommons.CommonsLog;
+
+              @CommonsLog
+              class Test {
+                  void method() {
+                      log.info("uh oh");
+                  }
+              }
+              """,
+            """
+              import lombok.extern.slf4j.Slf4j;
+
+              @Slf4j
+              class Test {
+                  void method() {
+                      log.info("uh oh");
                   }
               }
               """


### PR DESCRIPTION
## What's changed?
Add a new recipe `ChangeLombokLogAnnotation` and use that to migrate lombok annotations too, when switching to Log4j2 or Slf4j.

## What's your motivation?
Lombok annotations were missed, leading to an incomplete migration.

## Anything in particular you'd like reviewers to focus on?
`Sl4fJ` is now the default for a nullable argument. Any chance that interferes with how `getRecipeList()` returns a dynamic list?

## Have you considered any alternatives or workarounds?
Could have gone with explicit ChangeType recipes in Yaml, but those would have been repetitive as we add more logging frameworks, such as commons-logging last week.