### PR TITLE
Fix concurrent modification exception when using JUL

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/SystemErrToLogging.java
+++ b/src/main/java/org/openrewrite/java/logging/SystemErrToLogging.java
@@ -150,15 +150,13 @@ public class SystemErrToLogging extends Recipe {
                     print = replaceMethodInvocation(printCursor, ctx, exceptionPrintStackTrace, print, logField);
                 } else if (addLogger != null && addLogger) {
                     doAfterVisit(AddLogger.addLogger(clazz, framework, loggerName == null ? "logger" : loggerName));
-                    // the print statement will be replaced on the subsequent pass
-                    doAfterVisit(this);
                 }
                 return print;
             }
 
-            private J.MethodInvocation replaceMethodInvocation(Cursor printCursor, ExecutionContext ctx, Expression exceptionPrintStackTrace, J.MethodInvocation print, J.Identifier computedLoggerName) {
+            private J.MethodInvocation replaceMethodInvocation(Cursor printCursor, ExecutionContext ctx, @Nullable Expression exceptionPrintStackTrace, J.MethodInvocation print, J.Identifier computedLoggerName) {
                 if (exceptionPrintStackTrace == null) {
-                    print = getErrorTemplateNoException(this)
+                    print = getErrorTemplateNoException()
                             .apply(
                                     printCursor,
                                     print.getCoordinates().replace(),
@@ -183,7 +181,7 @@ public class SystemErrToLogging extends Recipe {
                         .visitNonNull(print, ctx, printCursor);
             }
 
-            public <P> JavaTemplate getErrorTemplateNoException(JavaVisitor<P> visitor) {
+            public JavaTemplate getErrorTemplateNoException() {
                 switch (framework) {
                     case SLF4J:
                         return JavaTemplate

--- a/src/main/java/org/openrewrite/java/logging/SystemOutToLogging.java
+++ b/src/main/java/org/openrewrite/java/logging/SystemOutToLogging.java
@@ -109,15 +109,12 @@ public class SystemOutToLogging extends Recipe {
                     print = replaceMethodInvocation(printCursor, ctx, print, logField);
                 } else if (addLogger != null && addLogger) {
                     doAfterVisit(AddLogger.addLogger(clazz, framework, loggerName == null ? "logger" : loggerName));
-
-                    // the print statement will be replaced on the subsequent pass
-                    doAfterVisit(this);
                 }
                 return print;
             }
 
             private J.MethodInvocation replaceMethodInvocation(Cursor printCursor, ExecutionContext ctx, J.MethodInvocation print, J.Identifier computedLoggerName) {
-                print = getInfoTemplate(this).apply(
+                print = getInfoTemplate().apply(
                         printCursor,
                         print.getCoordinates().replace(),
                         computedLoggerName,
@@ -133,7 +130,7 @@ public class SystemOutToLogging extends Recipe {
                 return print;
             }
 
-            private <P> JavaTemplate getInfoTemplate(JavaVisitor<P> visitor) {
+            private JavaTemplate getInfoTemplate() {
                 String levelOrDefault = getLevel();
                 switch (framework) {
                     case SLF4J:

--- a/src/test/java/org/openrewrite/java/logging/SystemOutToLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/SystemOutToLoggingTest.java
@@ -125,4 +125,36 @@ class SystemOutToLoggingTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/125")
+    void doNotDeleteFile() {
+        rewriteRun(
+          spec -> spec
+            .recipe(new SystemOutToLogging(true, "log", "JUL", null)),
+          //language=java
+          java(
+            """
+              class Foo {
+                void bar() {
+                  System.out.println("Test");
+                }
+              }
+              """,
+            """
+              import java.util.logging.Level;
+              import java.util.logging.LogManager;
+              import java.util.logging.Logger;
+                            
+              class Foo {
+                  private static final Logger log = LogManager.getLogger("Foo");
+                            
+                  void bar() {
+                      log.log(Level.INFO, "Test");
+                }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Add a test that brought to light a concurrent modification exception with `doAfterVisit(this)`.
Removing that statement already made all the tests we have pass.
Then followup fixes as prompted by IDE warnings, as per team convention.

## What's your motivation?
Fixes #125

## Any additional context
- #125