### PR TITLE
Add JCL to Log4j API migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/log4j.yml
+++ b/src/main/resources/META-INF/rewrite/log4j.yml
@@ -116,3 +116,29 @@ recipeList:
       newGroupId: org.apache.logging.log4j
       newArtifactId: log4j-slf4j-impl
       newVersion: latest.release
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.logging.log4j.CommonsLoggingToLog4j
+displayName: Migrate JCL to Log4j 2.x API.
+description: Transforms code written using Apache Commons Logging to use Log4j 2.x API.
+tags:
+  - logging
+  - commons-logging
+  - log4j
+recipeList:
+  - org.openrewrite.java.SimplifyMethodChain:
+      methodPatternChain:
+        - org.apache.commons.logging.LogFactory getFactory()
+        - org.apache.commons.logging.LogFactory getInstance(..)
+      newMethodName: getLogger
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.commons.logging.LogFactory getLog(..)
+      newMethodName: getLogger
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.commons.logging.LogFactory
+      newFullyQualifiedTypeName: org.apache.logging.log4j.LogManager
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.commons.logging.Log
+      newFullyQualifiedTypeName: org.apache.logging.log4j.Logger
+  - org.openrewrite.java.logging.ChangeLombokLogAnnotation:
+      loggingFramework: Log4j2

--- a/src/test/java/org/openrewrite/java/logging/log4j/CommonsLoggingToLog4jTest.java
+++ b/src/test/java/org/openrewrite/java/logging/log4j/CommonsLoggingToLog4jTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.logging.log4j;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+public class CommonsLoggingToLog4jTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResource("/META-INF/rewrite/log4j.yml",
+                        "org.openrewrite.java.logging.log4j.CommonsLoggingToLog4j")
+                .parser(JavaParser.fromJavaVersion().classpath("log4j-api", "commons-logging", "lombok"));
+    }
+
+    @DocumentExample
+    @Test
+    void loggerFactoryToLogManager() {
+        // language=java
+        rewriteRun(java("""
+                import org.apache.commons.logging.LogFactory;
+                import org.apache.commons.logging.Log;
+
+                class Test {
+                    Log log1 = LogFactory.getLog(Test.class);
+                    Log log2 = LogFactory.getLog("Test");
+                    Log log3 = LogFactory.getFactory().getInstance(Test.class);
+                    Log log4 = LogFactory.getFactory().getInstance("Test");
+                }
+                """, """
+                import org.apache.logging.log4j.LogManager;
+                import org.apache.logging.log4j.Logger;
+
+                class Test {
+                    Logger log1 = LogManager.getLogger(Test.class);
+                    Logger log2 = LogManager.getLogger("Test");
+                    Logger log3 = LogManager.getLogger(Test.class);
+                    Logger log4 = LogManager.getLogger("Test");
+                }
+                """));
+    }
+
+    @Test
+    void changeLombokLogAnnotation() {
+        // language=java
+        rewriteRun(spec -> spec.typeValidationOptions(TypeValidation.builder()
+                .identifiers(false)
+                .methodInvocations(false)
+                .build()), java("""
+                import lombok.extern.apachecommons.CommonsLog;
+
+                @CommonsLog
+                class Test {
+                    void method() {
+                        log.info("uh oh");
+                    }
+                }
+                """, """
+                import lombok.extern.log4j.Log4j2;
+
+                @Log4j2
+                class Test {
+                    void method() {
+                        log.info("uh oh");
+                    }
+                }
+                """));
+    }
+}

--- a/src/test/java/org/openrewrite/java/logging/log4j/CommonsLoggingToLog4jTest.java
+++ b/src/test/java/org/openrewrite/java/logging/log4j/CommonsLoggingToLog4jTest.java
@@ -15,8 +15,6 @@
  */
 package org.openrewrite.java.logging.log4j;
 
-import static org.openrewrite.java.Assertions.java;
-
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
@@ -24,66 +22,78 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
-public class CommonsLoggingToLog4jTest implements RewriteTest {
+import static org.openrewrite.java.Assertions.java;
 
+class CommonsLoggingToLog4jTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResource("/META-INF/rewrite/log4j.yml",
-                        "org.openrewrite.java.logging.log4j.CommonsLoggingToLog4j")
-                .parser(JavaParser.fromJavaVersion().classpath("log4j-api", "commons-logging", "lombok"));
+            "org.openrewrite.java.logging.log4j.CommonsLoggingToLog4j")
+          .parser(JavaParser.fromJavaVersion().classpath("log4j-api", "commons-logging", "lombok"));
     }
 
     @DocumentExample
     @Test
     void loggerFactoryToLogManager() {
         // language=java
-        rewriteRun(java("""
-                import org.apache.commons.logging.LogFactory;
-                import org.apache.commons.logging.Log;
+        rewriteRun(
+          java(
+            """
+              import org.apache.commons.logging.LogFactory;
+              import org.apache.commons.logging.Log;
 
-                class Test {
-                    Log log1 = LogFactory.getLog(Test.class);
-                    Log log2 = LogFactory.getLog("Test");
-                    Log log3 = LogFactory.getFactory().getInstance(Test.class);
-                    Log log4 = LogFactory.getFactory().getInstance("Test");
-                }
-                """, """
-                import org.apache.logging.log4j.LogManager;
-                import org.apache.logging.log4j.Logger;
+              class Test {
+                  Log log1 = LogFactory.getLog(Test.class);
+                  Log log2 = LogFactory.getLog("Test");
+                  Log log3 = LogFactory.getFactory().getInstance(Test.class);
+                  Log log4 = LogFactory.getFactory().getInstance("Test");
+              }
+              """,
+            """
+              import org.apache.logging.log4j.LogManager;
+              import org.apache.logging.log4j.Logger;
 
-                class Test {
-                    Logger log1 = LogManager.getLogger(Test.class);
-                    Logger log2 = LogManager.getLogger("Test");
-                    Logger log3 = LogManager.getLogger(Test.class);
-                    Logger log4 = LogManager.getLogger("Test");
-                }
-                """));
+              class Test {
+                  Logger log1 = LogManager.getLogger(Test.class);
+                  Logger log2 = LogManager.getLogger("Test");
+                  Logger log3 = LogManager.getLogger(Test.class);
+                  Logger log4 = LogManager.getLogger("Test");
+              }
+              """
+          )
+        );
     }
 
     @Test
     void changeLombokLogAnnotation() {
         // language=java
-        rewriteRun(spec -> spec.typeValidationOptions(TypeValidation.builder()
-                .identifiers(false)
-                .methodInvocations(false)
-                .build()), java("""
-                import lombok.extern.apachecommons.CommonsLog;
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.builder()
+            .identifiers(false)
+            .methodInvocations(false)
+            .build()),
+          java(
+            """
+              import lombok.extern.apachecommons.CommonsLog;
 
-                @CommonsLog
-                class Test {
-                    void method() {
-                        log.info("uh oh");
-                    }
-                }
-                """, """
-                import lombok.extern.log4j.Log4j2;
+              @CommonsLog
+              class Test {
+                  void method() {
+                      log.info("uh oh");
+                  }
+              }
+              """,
+            """
+              import lombok.extern.log4j.Log4j2;
 
-                @Log4j2
-                class Test {
-                    void method() {
-                        log.info("uh oh");
-                    }
-                }
-                """));
+              @Log4j2
+              class Test {
+                  void method() {
+                      log.info("uh oh");
+                  }
+              }
+              """
+          )
+        );
     }
 }


### PR DESCRIPTION
## What's changed?

This PR adds a recipe to migrate from Apache Commons Logging to Log4j 2.x API: `org.openrewrite.java.logging.log4j.CommonsLoggingToLog4j`.

## What's your motivation?

While it has an excellent SLF4J support `rewrite-logging-frameworks` is somehow lacking _vis-à-vis_ Log4j 2.x API support.

As part of apache/logging-log4j2#2080 we plan to cover all conversions between the most popular logging APIs and Log4j API and between the most popular logging backends and Log4j Core. I would appreciate if these recipes could be included in an official OpenRewrite artifact.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
