### PR TITLE
Add basic JUL to Log4j API conversion

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/log4j/ConvertJulEntering.java
+++ b/src/main/java/org/openrewrite/java/logging/log4j/ConvertJulEntering.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.logging.log4j;
+
+import static java.util.Objects.requireNonNull;
+import static org.openrewrite.Tree.randomId;
+
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.java.tree.J.Identifier;
+import org.openrewrite.java.tree.JavaType.Method;
+import org.openrewrite.java.tree.JavaType.Primitive;
+import org.openrewrite.marker.Markers;
+
+/**
+ * This recipe rewrites JUL's {@link java.util.logging.Logger#entering} method.
+ */
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class ConvertJulEntering extends Recipe {
+
+    private static final String METHOD_PATTERN = "java.util.logging.Logger entering(..)";
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder {
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Rewrites JUL's Logger#entering method to Log4j API";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replaces JUL's Logger#entering method calls to Log4j API Logger#traceEntry calls.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new JavaVisitor<ExecutionContext>() {
+            @Override
+            public J visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (tree instanceof JavaSourceFile) {
+                    JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
+                    return new UsesMethod<>(METHOD_PATTERN).visitNonNull(cu, ctx);
+                }
+                return super.visit(tree, ctx);
+            }
+        }, new EnteringMethodVisitor(new MethodMatcher(METHOD_PATTERN, false)));
+    }
+
+    private class EnteringMethodVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private final MethodMatcher methodMatcher;
+
+        private EnteringMethodVisitor(MethodMatcher methodMatcher) {
+            this.methodMatcher = methodMatcher;
+        }
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            return (J.MethodInvocation) visitMethodCall(super.visitMethodInvocation(method, ctx));
+        }
+
+        private J.MethodInvocation visitMethodCall(J.MethodInvocation m) {
+            if (methodMatcher.matches(m) && m.getMethodType() != null) {
+                final List<Expression> originalArgs = m.getArguments();
+                final int originalArgCount = originalArgs.size();
+                if (originalArgCount < 2 || 3 < originalArgCount) {
+                    throw new IllegalArgumentException("Unsupported Logger#entering method: " + m.getMethodType());
+                }
+                final List<Expression> modifiedArgs = new ArrayList<>();
+                final List<JavaType> modifiedTypes = new ArrayList<>();
+                final J.Literal nullString = buildNullString();
+                modifiedArgs.add(nullString);
+                modifiedTypes.add(Primitive.String);
+                if (originalArgCount > 2) {
+                    final JavaType varargType = JavaType.buildType("java.lang.Object[]");
+                    modifiedArgs.add(originalArgs.get(2));
+                    modifiedTypes.add(varargType);
+                }
+                final Identifier traceEntry = m.getName().withSimpleName("traceEntry");
+                final Method mt = m.getMethodType().withParameterTypes(modifiedTypes);
+                return m.withMethodType(mt)
+                        .withName(traceEntry)
+                        .withArguments(modifiedArgs)
+                        .withDeclaringType(mt.getDeclaringType()
+                                .withFullyQualifiedName("org.apache.logging.log4j.Logger"));
+            }
+            return m;
+        }
+    }
+
+    private static J.Literal buildNullString() {
+        return new J.Literal(randomId(), Space.EMPTY, Markers.EMPTY, null, "null", null, JavaType.Primitive.String);
+    }
+}

--- a/src/main/java/org/openrewrite/java/logging/log4j/ConvertJulEntering.java
+++ b/src/main/java/org/openrewrite/java/logging/log4j/ConvertJulEntering.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/openrewrite/java/logging/log4j/ConvertJulEntering.java
+++ b/src/main/java/org/openrewrite/java/logging/log4j/ConvertJulEntering.java
@@ -15,25 +15,27 @@
  */
 package org.openrewrite.java.logging.log4j;
 
-import static java.util.Objects.requireNonNull;
-import static org.openrewrite.Tree.randomId;
-
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
-import org.openrewrite.*;
-import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
-import org.openrewrite.java.tree.*;
-import org.openrewrite.java.tree.J.Identifier;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.JavaType.Method;
 import org.openrewrite.java.tree.JavaType.Primitive;
+import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Markers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.openrewrite.Tree.randomId;
 
 /**
  * This recipe rewrites JUL's {@link java.util.logging.Logger#entering} method.
@@ -42,11 +44,7 @@ import org.openrewrite.marker.Markers;
 @EqualsAndHashCode(callSuper = true)
 public class ConvertJulEntering extends Recipe {
 
-    private static final String METHOD_PATTERN = "java.util.logging.Logger entering(..)";
-
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class Builder {
-    }
+    private static final MethodMatcher METHOD_MATCHER = new MethodMatcher("java.util.logging.Logger entering(String, String, ..)", false);
 
     @Override
     public String getDisplayName() {
@@ -60,60 +58,39 @@ public class ConvertJulEntering extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new JavaVisitor<ExecutionContext>() {
-            @Override
-            public J visit(@Nullable Tree tree, ExecutionContext ctx) {
-                if (tree instanceof JavaSourceFile) {
-                    JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
-                    return new UsesMethod<>(METHOD_PATTERN).visitNonNull(cu, ctx);
+        return Preconditions.check(new UsesMethod<>(METHOD_MATCHER), new JavaIsoVisitor<ExecutionContext>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                        J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+                        if (METHOD_MATCHER.matches(m)) {
+                            List<Expression> originalArgs = m.getArguments();
+                            int originalArgCount = originalArgs.size();
+                            if (3 < originalArgCount) {
+                                return m;
+                            }
+                            List<Expression> modifiedArgs = new ArrayList<>();
+                            List<JavaType> modifiedTypes = new ArrayList<>();
+                            modifiedArgs.add(buildNullString());
+                            modifiedTypes.add(Primitive.String);
+                            if (originalArgCount > 2) {
+                                JavaType varargType = JavaType.buildType("java.lang.Object[]");
+                                modifiedArgs.add(originalArgs.get(2));
+                                modifiedTypes.add(varargType);
+                            }
+                            Method mt = m.getMethodType().withParameterTypes(modifiedTypes);
+                            JavaType.FullyQualified dt = mt.getDeclaringType().withFullyQualifiedName("org.apache.logging.log4j.Logger");
+                            return m.withMethodType(mt)
+                                    .withName(m.getName().withSimpleName("traceEntry"))
+                                    .withArguments(modifiedArgs)
+                                    .withDeclaringType(dt);
+                        }
+                        return m;
+                    }
+
+                    private J.Literal buildNullString() {
+                        return new J.Literal(randomId(), Space.EMPTY, Markers.EMPTY, null, "null", null, JavaType.Primitive.String);
+                    }
                 }
-                return super.visit(tree, ctx);
-            }
-        }, new EnteringMethodVisitor(new MethodMatcher(METHOD_PATTERN, false)));
-    }
-
-    private class EnteringMethodVisitor extends JavaIsoVisitor<ExecutionContext> {
-        private final MethodMatcher methodMatcher;
-
-        private EnteringMethodVisitor(MethodMatcher methodMatcher) {
-            this.methodMatcher = methodMatcher;
-        }
-
-        @Override
-        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-            return (J.MethodInvocation) visitMethodCall(super.visitMethodInvocation(method, ctx));
-        }
-
-        private J.MethodInvocation visitMethodCall(J.MethodInvocation m) {
-            if (methodMatcher.matches(m) && m.getMethodType() != null) {
-                final List<Expression> originalArgs = m.getArguments();
-                final int originalArgCount = originalArgs.size();
-                if (originalArgCount < 2 || 3 < originalArgCount) {
-                    throw new IllegalArgumentException("Unsupported Logger#entering method: " + m.getMethodType());
-                }
-                final List<Expression> modifiedArgs = new ArrayList<>();
-                final List<JavaType> modifiedTypes = new ArrayList<>();
-                final J.Literal nullString = buildNullString();
-                modifiedArgs.add(nullString);
-                modifiedTypes.add(Primitive.String);
-                if (originalArgCount > 2) {
-                    final JavaType varargType = JavaType.buildType("java.lang.Object[]");
-                    modifiedArgs.add(originalArgs.get(2));
-                    modifiedTypes.add(varargType);
-                }
-                final Identifier traceEntry = m.getName().withSimpleName("traceEntry");
-                final Method mt = m.getMethodType().withParameterTypes(modifiedTypes);
-                return m.withMethodType(mt)
-                        .withName(traceEntry)
-                        .withArguments(modifiedArgs)
-                        .withDeclaringType(mt.getDeclaringType()
-                                .withFullyQualifiedName("org.apache.logging.log4j.Logger"));
-            }
-            return m;
-        }
-    }
-
-    private static J.Literal buildNullString() {
-        return new J.Literal(randomId(), Space.EMPTY, Markers.EMPTY, null, "null", null, JavaType.Primitive.String);
+        );
     }
 }

--- a/src/main/java/org/openrewrite/java/logging/log4j/ConvertJulExiting.java
+++ b/src/main/java/org/openrewrite/java/logging/log4j/ConvertJulExiting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2023 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/openrewrite/java/logging/log4j/ConvertJulExiting.java
+++ b/src/main/java/org/openrewrite/java/logging/log4j/ConvertJulExiting.java
@@ -25,15 +25,10 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.*;
-import org.openrewrite.java.tree.J.Identifier;
 import org.openrewrite.java.tree.JavaType.Method;
-import org.openrewrite.java.tree.JavaType.Primitive;
-import org.openrewrite.marker.Markers;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.openrewrite.Tree.randomId;
 
 /**
  * This recipe rewrites JUL's {@link java.util.logging.Logger#entering} method.

--- a/src/main/java/org/openrewrite/java/logging/log4j/ConvertJulExiting.java
+++ b/src/main/java/org/openrewrite/java/logging/log4j/ConvertJulExiting.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.logging.log4j;
+
+import static java.util.Objects.requireNonNull;
+import static org.openrewrite.Tree.randomId;
+
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.*;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.java.tree.J.Identifier;
+import org.openrewrite.java.tree.JavaType.Method;
+import org.openrewrite.java.tree.JavaType.Primitive;
+import org.openrewrite.marker.Markers;
+
+/**
+ * This recipe rewrites JUL's {@link java.util.logging.Logger#entering} method.
+ */
+@Value
+@EqualsAndHashCode(callSuper = true)
+public class ConvertJulExiting extends Recipe {
+
+    private static final String METHOD_PATTERN = "java.util.logging.Logger exiting(..)";
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder {
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Rewrites JUL's Logger#exiting method to Log4j API";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replaces JUL's Logger#exiting method calls to Log4j API Logger#traceEntry calls.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new JavaVisitor<ExecutionContext>() {
+            @Override
+            public J visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (tree instanceof JavaSourceFile) {
+                    JavaSourceFile cu = (JavaSourceFile) requireNonNull(tree);
+                    return new UsesMethod<>(METHOD_PATTERN).visitNonNull(cu, ctx);
+                }
+                return super.visit(tree, ctx);
+            }
+        }, new EnteringMethodVisitor(new MethodMatcher(METHOD_PATTERN, false)));
+    }
+
+    private class EnteringMethodVisitor extends JavaIsoVisitor<ExecutionContext> {
+        private final MethodMatcher methodMatcher;
+
+        private EnteringMethodVisitor(MethodMatcher methodMatcher) {
+            this.methodMatcher = methodMatcher;
+        }
+
+        @Override
+        public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+            return (J.MethodInvocation) visitMethodCall(super.visitMethodInvocation(method, ctx));
+        }
+
+        private J.MethodInvocation visitMethodCall(J.MethodInvocation m) {
+            if (methodMatcher.matches(m) && m.getMethodType() != null) {
+                final List<JRightPadded<Expression>> originalArgs = m.getPadding()
+                        .getArguments()
+                        .getPadding()
+                        .getElements();
+                final List<JavaType> originalTypes = m.getMethodType().getParameterTypes();
+                final int originalArgCount = originalArgs.size();
+                if (originalArgCount < 2 || 3 < originalArgCount) {
+                    throw new IllegalArgumentException("Unsupported Logger#entering method: " + m.getMethodType());
+                }
+                final List<Expression> modifiedArgs = new ArrayList<>();
+                final List<JavaType> modifiedTypes = new ArrayList<>();
+                if (originalArgCount > 2) {
+                    modifiedArgs.add(originalArgs.get(2).getElement().withPrefix(Space.EMPTY));
+                    modifiedTypes.add(originalTypes.get(2));
+                }
+                final Identifier traceEntry = m.getName().withSimpleName("traceExit");
+                final Method mt = m.getMethodType().withParameterTypes(modifiedTypes);
+                return m.withMethodType(mt)
+                        .withName(traceEntry)
+                        .withDeclaringType(mt.getDeclaringType()
+                                .withFullyQualifiedName("org.apache.logging.log4j.Logger"))
+                        .withArguments(modifiedArgs);
+            }
+            return m;
+        }
+    }
+
+    private static J.Literal buildNullString() {
+        return new J.Literal(randomId(), Space.EMPTY, Markers.EMPTY, null, "null", null, Primitive.String);
+    }
+}

--- a/src/main/resources/META-INF/rewrite/log4j.yml
+++ b/src/main/resources/META-INF/rewrite/log4j.yml
@@ -142,3 +142,45 @@ recipeList:
       newFullyQualifiedTypeName: org.apache.logging.log4j.Logger
   - org.openrewrite.java.logging.ChangeLombokLogAnnotation:
       loggingFramework: Log4j2
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.logging.log4j.JulToLog4j
+displayName: Migrate JUL to Log4j 2.x API.
+description: Transforms code written using `java.util.logging` to use Log4j 2.x API.
+tags:
+  - logging
+  - java-util-logging
+  - log4j
+recipeList:
+  - org.openrewrite.java.ChangeMethodTargetToStatic:
+      methodPattern: java.util.logging.Logger getLogger(..)
+      fullyQualifiedTargetTypeName: org.apache.logging.log4j.LogManager
+  # Change method names.
+  # The levels that do not have an equivalent are rounded up (less specific)
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: java.util.logging.Logger config(..)
+      newMethodName: info
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: java.util.logging.Logger fine(..)
+      newMethodName: debug
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: java.util.logging.Logger finer(..)
+      newMethodName: trace
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: java.util.logging.Logger finest(..)
+      newMethodName: trace
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: java.util.logging.Logger severe(..)
+      newMethodName: error
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: java.util.logging.Logger warning(..)
+      newMethodName: warn
+  # entering/exiting calls
+  - org.openrewrite.java.logging.log4j.ConvertJulEntering
+  - org.openrewrite.java.logging.log4j.ConvertJulExiting
+  # Change logger type
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: java.util.logging.Logger
+      newFullyQualifiedTypeName: org.apache.logging.log4j.Logger
+  - org.openrewrite.java.logging.ChangeLombokLogAnnotation:
+      loggingFramework: Log4j2

--- a/src/test/java/org/openrewrite/java/logging/log4j/ConvertJulEnteringTest.java
+++ b/src/test/java/org/openrewrite/java/logging/log4j/ConvertJulEnteringTest.java
@@ -15,8 +15,6 @@
  */
 package org.openrewrite.java.logging.log4j;
 
-import static org.openrewrite.java.Assertions.java;
-
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.java.ChangeType;
@@ -24,7 +22,9 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-public class ConvertJulEnteringTest implements RewriteTest {
+import static org.openrewrite.java.Assertions.java;
+
+class ConvertJulEnteringTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipes(new ConvertJulEntering(),
@@ -35,27 +35,32 @@ public class ConvertJulEnteringTest implements RewriteTest {
     @Test
     @DocumentExample
     void enteringToTraceEntry() {
-        // language=java
-        rewriteRun(java("""
-          import java.util.logging.Logger;
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import java.util.logging.Logger;
 
-          class Test {
-              void method(Logger logger) {
-                logger.entering("Test", "method");
-                logger.entering("Test", "method", "param");
-                logger.entering("Test", "method", new Object[]{"param1", "param2"});
+              class Test {
+                  void method(Logger logger) {
+                    logger.entering("Test", "method");
+                    logger.entering("Test", "method", "param");
+                    logger.entering("Test", "method", new Object[]{"param1", "param2"});
+                  }
               }
-          }
-          """, """
-          import org.apache.logging.log4j.Logger;
+              """,
+            """
+              import org.apache.logging.log4j.Logger;
 
-          class Test {
-              void method(Logger logger) {
-                logger.traceEntry(null);
-                logger.traceEntry(null, "param");
-                logger.traceEntry(null, new Object[]{"param1", "param2"});
+              class Test {
+                  void method(Logger logger) {
+                    logger.traceEntry(null);
+                    logger.traceEntry(null, "param");
+                    logger.traceEntry(null, new Object[]{"param1", "param2"});
+                  }
               }
-          }
-          """));
+              """
+          )
+        );
     }
 }

--- a/src/test/java/org/openrewrite/java/logging/log4j/ConvertJulEnteringTest.java
+++ b/src/test/java/org/openrewrite/java/logging/log4j/ConvertJulEnteringTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.logging.log4j;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.ChangeType;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+public class ConvertJulEnteringTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipes(new ConvertJulEntering(),
+            new ChangeType("java.util.logging.Logger", "org.apache.logging.log4j.Logger", true))
+          .parser(JavaParser.fromJavaVersion().classpath("log4j-api"));
+    }
+
+    @Test
+    @DocumentExample
+    void enteringToTraceEntry() {
+        // language=java
+        rewriteRun(java("""
+          import java.util.logging.Logger;
+
+          class Test {
+              void method(Logger logger) {
+                logger.entering("Test", "method");
+                logger.entering("Test", "method", "param");
+                logger.entering("Test", "method", new Object[]{"param1", "param2"});
+              }
+          }
+          """, """
+          import org.apache.logging.log4j.Logger;
+
+          class Test {
+              void method(Logger logger) {
+                logger.traceEntry(null);
+                logger.traceEntry(null, "param");
+                logger.traceEntry(null, new Object[]{"param1", "param2"});
+              }
+          }
+          """));
+    }
+}

--- a/src/test/java/org/openrewrite/java/logging/log4j/ConvertJulExitingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/log4j/ConvertJulExitingTest.java
@@ -15,8 +15,6 @@
  */
 package org.openrewrite.java.logging.log4j;
 
-import static org.openrewrite.java.Assertions.java;
-
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.java.ChangeType;
@@ -24,7 +22,9 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
-public class ConvertJulExitingTest implements RewriteTest {
+import static org.openrewrite.java.Assertions.java;
+
+class ConvertJulExitingTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipes(new ConvertJulExiting(),
@@ -35,25 +35,30 @@ public class ConvertJulExitingTest implements RewriteTest {
     @Test
     @DocumentExample
     void exitingToTraceExit() {
-        // language=java
-        rewriteRun(java("""
-          import java.util.logging.Logger;
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import java.util.logging.Logger;
 
-          class Test {
-              void method(Logger logger) {
-                logger.exiting("Test", "method");
-                logger.exiting("Test", "method", "result");
+              class Test {
+                  void method(Logger logger) {
+                    logger.exiting("Test", "method");
+                    logger.exiting("Test", "method", "result");
+                  }
               }
-          }
-          """, """
-          import org.apache.logging.log4j.Logger;
+              """,
+            """
+              import org.apache.logging.log4j.Logger;
 
-          class Test {
-              void method(Logger logger) {
-                logger.traceExit();
-                logger.traceExit("result");
+              class Test {
+                  void method(Logger logger) {
+                    logger.traceExit();
+                    logger.traceExit("result");
+                  }
               }
-          }
-          """));
+              """
+          )
+        );
     }
 }

--- a/src/test/java/org/openrewrite/java/logging/log4j/ConvertJulExitingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/log4j/ConvertJulExitingTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.logging.log4j;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.ChangeType;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+public class ConvertJulExitingTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipes(new ConvertJulExiting(),
+            new ChangeType("java.util.logging.Logger", "org.apache.logging.log4j.Logger", true))
+          .parser(JavaParser.fromJavaVersion().classpath("log4j-api"));
+    }
+
+    @Test
+    @DocumentExample
+    void exitingToTraceExit() {
+        // language=java
+        rewriteRun(java("""
+          import java.util.logging.Logger;
+
+          class Test {
+              void method(Logger logger) {
+                logger.exiting("Test", "method");
+                logger.exiting("Test", "method", "result");
+              }
+          }
+          """, """
+          import org.apache.logging.log4j.Logger;
+
+          class Test {
+              void method(Logger logger) {
+                logger.traceExit();
+                logger.traceExit("result");
+              }
+          }
+          """));
+    }
+}

--- a/src/test/java/org/openrewrite/java/logging/log4j/JulToLog4jTest.java
+++ b/src/test/java/org/openrewrite/java/logging/log4j/JulToLog4jTest.java
@@ -24,7 +24,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
-public class JulToLog4jTest implements RewriteTest {
+class JulToLog4jTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResource("/META-INF/rewrite/log4j.yml", "org.openrewrite.java.logging.log4j.JulToLog4j")
@@ -33,96 +33,109 @@ public class JulToLog4jTest implements RewriteTest {
 
     @Test
     void loggerToLogManager() {
-        // language=java
-        rewriteRun(java("""
-          import java.util.logging.Logger;
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import java.util.logging.Logger;
 
-          class Test {
-              Logger log = Logger.getLogger("Test");
-          }
-          """, """
-          import org.apache.logging.log4j.LogManager;
-          import org.apache.logging.log4j.Logger;
+              class Test {
+                  Logger log = Logger.getLogger("Test");
+              }
+              """, """
+              import org.apache.logging.log4j.LogManager;
+              import org.apache.logging.log4j.Logger;
 
-          class Test {
-              Logger log = LogManager.getLogger("Test");
-          }
-          """));
+              class Test {
+                  Logger log = LogManager.getLogger("Test");
+              }
+              """
+          )
+        );
     }
 
     @Test
     @DocumentExample
     void simpleLoggerCalls() {
-        // language=java
-        rewriteRun(java("""
-          import java.util.logging.Logger;
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import java.util.logging.Logger;
 
-          class Test {
-              void method(Logger logger) {
-                logger.config("Hello");
-                logger.config(() -> "Hello");
-                logger.fine("Hello");
-                logger.fine(() -> "Hello");
-                logger.finer("Hello");
-                logger.finer(() -> "Hello");
-                logger.finest("Hello");
-                logger.finest(() -> "Hello");
-                logger.info("Hello");
-                logger.info(() -> "Hello");
-                logger.severe("Hello");
-                logger.severe(() -> "Hello");
-                logger.warning("Hello");
-                logger.warning(() -> "Hello");
+              class Test {
+                  void method(Logger logger) {
+                    logger.config("Hello");
+                    logger.config(() -> "Hello");
+                    logger.fine("Hello");
+                    logger.fine(() -> "Hello");
+                    logger.finer("Hello");
+                    logger.finer(() -> "Hello");
+                    logger.finest("Hello");
+                    logger.finest(() -> "Hello");
+                    logger.info("Hello");
+                    logger.info(() -> "Hello");
+                    logger.severe("Hello");
+                    logger.severe(() -> "Hello");
+                    logger.warning("Hello");
+                    logger.warning(() -> "Hello");
+                  }
               }
-          }
-          """, """
-          import org.apache.logging.log4j.Logger;
+              """,
+            """
+              import org.apache.logging.log4j.Logger;
 
-          class Test {
-              void method(Logger logger) {
-                logger.info("Hello");
-                logger.info(() -> "Hello");
-                logger.debug("Hello");
-                logger.debug(() -> "Hello");
-                logger.trace("Hello");
-                logger.trace(() -> "Hello");
-                logger.trace("Hello");
-                logger.trace(() -> "Hello");
-                logger.info("Hello");
-                logger.info(() -> "Hello");
-                logger.error("Hello");
-                logger.error(() -> "Hello");
-                logger.warn("Hello");
-                logger.warn(() -> "Hello");
+              class Test {
+                  void method(Logger logger) {
+                    logger.info("Hello");
+                    logger.info(() -> "Hello");
+                    logger.debug("Hello");
+                    logger.debug(() -> "Hello");
+                    logger.trace("Hello");
+                    logger.trace(() -> "Hello");
+                    logger.trace("Hello");
+                    logger.trace(() -> "Hello");
+                    logger.info("Hello");
+                    logger.info(() -> "Hello");
+                    logger.error("Hello");
+                    logger.error(() -> "Hello");
+                    logger.warn("Hello");
+                    logger.warn(() -> "Hello");
+                  }
               }
-          }
-          """));
+              """
+          )
+        );
     }
 
     @Test
     void changeLombokLogAnnotation() {
-        // language=java
         rewriteRun(spec -> spec.typeValidationOptions(TypeValidation.builder()
-          .identifiers(false)
-          .methodInvocations(false)
-          .build()), java("""
-          import lombok.extern.java.Log;
+            .identifiers(false)
+            .methodInvocations(false)
+            .build()),
+          // language=java
+          java(
+            """
+              import lombok.extern.java.Log;
 
-          @Log
-          class Test {
-              void method() {
-                  log.info("uh oh");
+              @Log
+              class Test {
+                  void method() {
+                      log.info("uh oh");
+                  }
               }
-          }
-          """, """
-          import lombok.extern.log4j.Log4j2;
+              """, """
+              import lombok.extern.log4j.Log4j2;
 
-          @Log4j2
-          class Test {
-              void method() {
-                  log.info("uh oh");
+              @Log4j2
+              class Test {
+                  void method() {
+                      log.info("uh oh");
+                  }
               }
-          }
-          """));
+              """
+          )
+        );
     }
 }

--- a/src/test/java/org/openrewrite/java/logging/log4j/JulToLog4jTest.java
+++ b/src/test/java/org/openrewrite/java/logging/log4j/JulToLog4jTest.java
@@ -15,14 +15,14 @@
  */
 package org.openrewrite.java.logging.log4j;
 
-import static org.openrewrite.java.Assertions.java;
-
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
 
 class JulToLog4jTest implements RewriteTest {
     @Override
@@ -42,7 +42,8 @@ class JulToLog4jTest implements RewriteTest {
               class Test {
                   Logger log = Logger.getLogger("Test");
               }
-              """, """
+              """,
+            """
               import org.apache.logging.log4j.LogManager;
               import org.apache.logging.log4j.Logger;
 
@@ -125,7 +126,8 @@ class JulToLog4jTest implements RewriteTest {
                       log.info("uh oh");
                   }
               }
-              """, """
+              """,
+            """
               import lombok.extern.log4j.Log4j2;
 
               @Log4j2

--- a/src/test/java/org/openrewrite/java/logging/log4j/JulToLog4jTest.java
+++ b/src/test/java/org/openrewrite/java/logging/log4j/JulToLog4jTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.logging.log4j;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+public class JulToLog4jTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResource("/META-INF/rewrite/log4j.yml", "org.openrewrite.java.logging.log4j.JulToLog4j")
+          .parser(JavaParser.fromJavaVersion().classpath("log4j-api", "lombok"));
+    }
+
+    @Test
+    void loggerToLogManager() {
+        // language=java
+        rewriteRun(java("""
+          import java.util.logging.Logger;
+
+          class Test {
+              Logger log = Logger.getLogger("Test");
+          }
+          """, """
+          import org.apache.logging.log4j.LogManager;
+          import org.apache.logging.log4j.Logger;
+
+          class Test {
+              Logger log = LogManager.getLogger("Test");
+          }
+          """));
+    }
+
+    @Test
+    @DocumentExample
+    void simpleLoggerCalls() {
+        // language=java
+        rewriteRun(java("""
+          import java.util.logging.Logger;
+
+          class Test {
+              void method(Logger logger) {
+                logger.config("Hello");
+                logger.config(() -> "Hello");
+                logger.fine("Hello");
+                logger.fine(() -> "Hello");
+                logger.finer("Hello");
+                logger.finer(() -> "Hello");
+                logger.finest("Hello");
+                logger.finest(() -> "Hello");
+                logger.info("Hello");
+                logger.info(() -> "Hello");
+                logger.severe("Hello");
+                logger.severe(() -> "Hello");
+                logger.warning("Hello");
+                logger.warning(() -> "Hello");
+              }
+          }
+          """, """
+          import org.apache.logging.log4j.Logger;
+
+          class Test {
+              void method(Logger logger) {
+                logger.info("Hello");
+                logger.info(() -> "Hello");
+                logger.debug("Hello");
+                logger.debug(() -> "Hello");
+                logger.trace("Hello");
+                logger.trace(() -> "Hello");
+                logger.trace("Hello");
+                logger.trace(() -> "Hello");
+                logger.info("Hello");
+                logger.info(() -> "Hello");
+                logger.error("Hello");
+                logger.error(() -> "Hello");
+                logger.warn("Hello");
+                logger.warn(() -> "Hello");
+              }
+          }
+          """));
+    }
+
+    @Test
+    void changeLombokLogAnnotation() {
+        // language=java
+        rewriteRun(spec -> spec.typeValidationOptions(TypeValidation.builder()
+          .identifiers(false)
+          .methodInvocations(false)
+          .build()), java("""
+          import lombok.extern.java.Log;
+
+          @Log
+          class Test {
+              void method() {
+                  log.info("uh oh");
+              }
+          }
+          """, """
+          import lombok.extern.log4j.Log4j2;
+
+          @Log4j2
+          class Test {
+              void method() {
+                  log.info("uh oh");
+              }
+          }
+          """));
+    }
+}


### PR DESCRIPTION
## What's changed?

This PR converts the most commonly used JUL methods to their Log4j API equivalents:

 * `Logger#getLogger`,
 * all `Logger#<logging_level` methods,
 * `Logger#entering`,
 * `Logger#exiting`.

## What's your motivation?

This is part of our apache/logging-log4j2#2080 task.
The main motivation is a user request for support (cf. apache/logging-log4j2#2083), hence the implementation of the `entering/exiting` rules.

Closes #132

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
