### PR TITLE
Add test for appended exception

### DIFF
--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -68,7 +68,7 @@ class ParameterizedLoggingTest implements RewriteTest {
     @Test
     void exceptionAppended() {
         rewriteRun(
-          spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger info(..)", false)),
+          spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger error(..)", false)),
           //language=java
           java(
             """

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -108,6 +108,7 @@ class ParameterizedLoggingTest implements RewriteTest {
     void noNeedToCallToStringOnParameterizedArgument() {
         rewriteRun(
           spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger info(..)", true)),
+          //language=java
           java(
             """
               import org.slf4j.Logger;

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -65,45 +65,6 @@ class ParameterizedLoggingTest implements RewriteTest {
         );
     }
 
-    @Test
-    @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/135")
-    void exceptionAppended() {
-        rewriteRun(
-          spec -> spec.recipeFromResources("org.openrewrite.java.logging.slf4j.ParameterizedLogging"),
-          //language=java
-          java(
-            """
-              import org.slf4j.Logger;
-
-              class Test {
-                  static void method(Logger logger, Class<?> clazz) {
-                      try {
-                          return clazz.newInstance();
-                      } catch (InstantiationException | IllegalAccessException ex) {
-                          logger.error("Cannot instantiate dependency: " + clazz, ex);
-                          return null;
-                      }
-                  }
-              }
-              """,
-            """
-              import org.slf4j.Logger;
-
-              class Test {
-                  static void method(Logger logger, Class<?> clazz) {
-                      try {
-                          return clazz.newInstance();
-                      } catch (InstantiationException | IllegalAccessException ex) {
-                          logger.error("Cannot instantiate dependency: {}", clazz, ex);
-                          return null;
-                      }
-                  }
-              }
-              """
-          )
-        );
-    }
-
     @SuppressWarnings("UnnecessaryToStringCall")
     @Test
     void noNeedToCallToStringOnParameterizedArgument() {
@@ -337,6 +298,7 @@ class ParameterizedLoggingTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/135")
     void exceptionArgumentsWithThrowable() {
         rewriteRun(
           spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger warn(..)", false)),

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -108,7 +108,6 @@ class ParameterizedLoggingTest implements RewriteTest {
     void noNeedToCallToStringOnParameterizedArgument() {
         rewriteRun(
           spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger info(..)", true)),
-          //language=java
           java(
             """
               import org.slf4j.Logger;

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -66,6 +66,7 @@ class ParameterizedLoggingTest implements RewriteTest {
     }
 
     @Test
+    @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/135")
     void exceptionAppended() {
         rewriteRun(
           spec -> spec.recipeFromResources("org.openrewrite.java.logging.slf4j.ParameterizedLogging"),

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -68,7 +68,7 @@ class ParameterizedLoggingTest implements RewriteTest {
     @Test
     void exceptionAppended() {
         rewriteRun(
-          spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger error(..)", false)),
+          spec -> spec.recipeFromResources("org.openrewrite.java.logging.slf4j.ParameterizedLogging"),
           //language=java
           java(
             """

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -65,6 +65,44 @@ class ParameterizedLoggingTest implements RewriteTest {
         );
     }
 
+    @Test
+    void exceptionAppended() {
+        rewriteRun(
+          spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger info(..)", false)),
+          //language=java
+          java(
+            """
+              import org.slf4j.Logger;
+
+              class Test {
+                  static void method(Logger logger, Class<?> clazz) {
+                      try {
+                          return clazz.newInstance();
+                      } catch (InstantiationException | IllegalAccessException ex) {
+                          logger.error("Cannot instantiate dependency: " + clazz, ex);
+                          return null;
+                      }
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+
+              class Test {
+                  static void method(Logger logger, Class<?> clazz) {
+                      try {
+                          return clazz.newInstance();
+                      } catch (InstantiationException | IllegalAccessException ex) {
+                          logger.error("Cannot instantiate dependency: {}", clazz, ex);
+                          return null;
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @SuppressWarnings("UnnecessaryToStringCall")
     @Test
     void noNeedToCallToStringOnParameterizedArgument() {


### PR DESCRIPTION
This refs https://github.com/openrewrite/rewrite-logging-frameworks/issues/135, but contributes only a small portion of the issue in question.

## What's changed?

Test added for checking rewrite of

    logger.error("Cannot instantiate dependency: " + clazz, ex);

to 

    logger.error("Cannot instantiate dependency: {}", clazz, ex);

