### PR TITLE
Adopt `log4j-slf4j2-impl` for SLF4 2+

### DIFF
--- a/src/main/resources/META-INF/rewrite/slf4j.yml
+++ b/src/main/resources/META-INF/rewrite/slf4j.yml
@@ -61,6 +61,12 @@ recipeList:
       artifactId: log4j-slf4j-impl
       version: latest.release
       onlyIfUsing: org.apache.log4j.*
+  # Adapt to breaking change in compatibility in the SLF4J binding API with SLF4J 2.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.apache.logging.log4j
+      oldArtifactId: log4j-slf4j-impl
+      newArtifactId: log4j-slf4j2-impl
+      newVersion: latest.release
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.logging.slf4j.ParameterizedLogging

--- a/src/main/resources/META-INF/rewrite/slf4j.yml
+++ b/src/main/resources/META-INF/rewrite/slf4j.yml
@@ -47,7 +47,7 @@ recipeList:
       onlyIfUsing: org.apache.logging.log4j.*
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: org.apache.logging.log4j
-      artifactId: log4j-slf4j-impl
+      artifactId: log4j-slf4j2-impl
       version: latest.release
       onlyIfUsing: org.apache.logging.log4j.*
   ### Additional AddDependency's since "onlyIfUsing" may think it isn't using log4j 2.x if doing an upgrade chaining from log4j1 recipes todo
@@ -58,7 +58,7 @@ recipeList:
       onlyIfUsing: org.apache.log4j.*
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: org.apache.logging.log4j
-      artifactId: log4j-slf4j-impl
+      artifactId: log4j-slf4j2-impl
       version: latest.release
       onlyIfUsing: org.apache.log4j.*
   # Adapt to breaking change in compatibility in the SLF4J binding API with SLF4J 2.x


### PR DESCRIPTION
## What's changed?
Add `log4j-slf4j2-impl` instead of `log4j-slf4j-impl`, and change any existing such dependencies.

## What's your motivation?
Since we're using `latest.release` we pick up SLF4J version 2+, which needs this altered binding implementation.

## Any additional context
- https://logging.apache.org/log4j/2.x/log4j-slf4j-impl.html