### PR TITLE
Fix LogManager logger call chain

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/AddLogger.java
+++ b/src/main/java/org/openrewrite/java/logging/AddLogger.java
@@ -80,7 +80,7 @@ public class AddLogger extends JavaIsoVisitor<ExecutionContext> {
     public static AddLogger addJulLogger(J.ClassDeclaration scope, String loggerName, @SuppressWarnings("unused") ExecutionContext ctx) {
         return new AddLogger(scope, "java.util.logging.Logger", "java.util.logging.LogManager", loggerName, visitor ->
                 JavaTemplate
-                        .builder("private static final Logger #{} = LogManager.getLogger(\"#{}\");")
+                        .builder("private static final Logger #{} = LogManager.getLogManager().getLogger(\"#{}\");")
                         .contextSensitive()
                         .imports("java.util.logging.Logger", "java.util.logging.LogManager")
                         .build()

--- a/src/test/java/org/openrewrite/java/logging/SystemOutToLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/SystemOutToLoggingTest.java
@@ -152,7 +152,7 @@ class SystemOutToLoggingTest implements RewriteTest {
               import java.util.logging.Logger;
                             
               class Foo {
-                  private static final Logger log = LogManager.getLogger("Foo");
+                  private static final Logger log = LogManager.getLogManager().getLogger("Foo");
                             
                   void bar() {
                       log.log(Level.INFO, "Test");


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
This produces the proper method chain to obtain a logger using JUL.

## What's your motivation?
Simple bugfix.

## Anything in particular you'd like reviewers to focus on?
I didn't change much, but a local build couldn't pass the two license tasks and a few tests just failed on some snakeyaml problems. But the scope of the changes is far from affecting anything there.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
N/A

## Any additional context
Unless you want a specific test that checks that code compiles there's not much to change or add of value in tests.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
