### PR TITLE
(doc) Description of Log4j 1 to Log4j 2 APi migration

### DIFF
--- a/src/main/resources/META-INF/rewrite/log4j.yml
+++ b/src/main/resources/META-INF/rewrite/log4j.yml
@@ -59,13 +59,9 @@ name: org.openrewrite.java.logging.log4j.Log4j1ToLog4j2
 displayName: Migrate Log4j 1.x to Log4j 2.x
 description: > 
   Migrates Log4j 1.x to Log4j 2.x. 
-  This remediates the [Log4Shell](https://www.cisa.gov/news-events/cybersecurity-advisories/aa21-356a) vulnerability 
-  by upgrading to latest version of Log4j 2.
 tags:
   - logging
   - log4j
-  - CVE-2021-44228
-  - Log4Shell
 recipeList:
   - org.openrewrite.java.logging.ChangeLombokLogAnnotation:
       loggingFramework: Log4J2


### PR DESCRIPTION
## What's changed?

This documentation-only PR changes the description of the "Migrate Log4j 1.x to Log4j 2.x" recipe.

## What's your motivation?

The description of the "Migrate Log4j 1.x to Log4j 2.x" recipe is incorrect.

Users might get the false impression that it mitigates the Log4Shell vulnerability. However:

- Log4j 1 was **never** affected by Log4Shell.
- only Log4j 2 Core was.

There are multiple reasons to migrate from Log4j 1, the first one is that the library is unsupported since 2015. Log4Shell mitigation is **not** one of them.
