### PR TITLE
Create a separate Log4Shell recipe

### DIFF
--- a/src/main/resources/META-INF/rewrite/log4j.yml
+++ b/src/main/resources/META-INF/rewrite/log4j.yml
@@ -116,6 +116,22 @@ recipeList:
       newGroupId: org.apache.logging.log4j
       newArtifactId: log4j-slf4j-impl
       newVersion: 2.x
+  - org.openrewrite.java.logging.log4j.UpgradeLog4J2DependencyVersion
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.logging.log4j.UpgradeLog4J2DependencyVersion
+displayName: Upgrade Log4j 2.x dependency version
+description: |
+  Upgrades the version of the Log4j 2.x dependency to the latest version.
+  Mitigates the [Log4Shell and other Log4j2-related vulnerabilities](https://www.cisa.gov/news-events/cybersecurity-advisories/aa21-356a).
+tags:
+  - logging
+  - log4j
+  - log4shell
+  - security
+  - CVE-2021-44228
+recipeList:
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.apache.logging.log4j
       artifactId: '*'
@@ -125,7 +141,7 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.logging.log4j.CommonsLoggingToLog4j
-displayName: Migrate JCL to Log4j 2.x API.
+displayName: Migrate JCL to Log4j 2.x API
 description: Transforms code written using Apache Commons Logging to use Log4j 2.x API.
 tags:
   - logging
@@ -151,7 +167,7 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.logging.log4j.JulToLog4j
-displayName: Migrate JUL to Log4j 2.x API.
+displayName: Migrate JUL to Log4j 2.x API
 description: Transforms code written using `java.util.logging` to use Log4j 2.x API.
 tags:
   - logging
@@ -193,7 +209,7 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.logging.log4j.Slf4jToLog4j
-displayName: Migrate SLF4J to Log4j 2.x API.
+displayName: Migrate SLF4J to Log4j 2.x API
 description: Transforms code written using SLF4J to use Log4j 2.x API.
 tags:
   - logging


### PR DESCRIPTION
## What's your motivation?
As requested on https://github.com/openrewrite/rewrite-logging-frameworks/pull/150#issuecomment-2145729761
Helps users find this recipe more easily.

## Have you considered any alternatives or workarounds?
Optionally we could also use preconditions to separately bump folks still on Java 6 or 7 to versions compatible with those, but I figured that's unlikely given that we require Java 8 to run OpenRewrite.
As per: https://logging.apache.org/log4j/2.x/security.html