### PR TITLE
ParameterizedLogging recipe fixed

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/ParameterizedLogging.java
+++ b/src/main/java/org/openrewrite/java/logging/ParameterizedLogging.java
@@ -80,7 +80,7 @@ public class ParameterizedLogging extends Recipe {
                     List<Expression> newArgList = new ArrayList<>();
                     boolean hasMarker = m.getArguments().size() > 1 
                             && m.getArguments().get(1) instanceof J.Identifier 
-                            && TypeUtils.isOfType(m.getArguments().get(1).getType(), Marker.class);
+                            && TypeUtils.isAssignableTo("org.slf4j.Marker", m.getArguments().get(1).getType());
                     
                     if (logMsg instanceof J.Binary) {
                         StringBuilder messageBuilder = new StringBuilder("\"");

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -597,7 +597,7 @@ class ParameterizedLoggingTest implements RewriteTest {
 
     @Test
     @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/159")
-    void parameterizedWithMarker() {
+    void concatenationWithMarker() {
         rewriteRun(
           spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger info(..)", false)),
           // language=java

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -35,7 +35,7 @@ class ParameterizedLoggingTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "slf4j-api-2.1", "log4j-api-2.23", "log4j-core-2.23"));;
+          .classpathFromResources(new InMemoryExecutionContext(), "slf4j-api-2.1", "log4j-api-2.23", "log4j-core-2.23"));
     }
 
     @DocumentExample
@@ -569,7 +569,7 @@ class ParameterizedLoggingTest implements RewriteTest {
           java(
             """
               import org.slf4j.Logger;
-              
+
               class Test {
                   static void method(Logger logger) {
                       String one = "one";
@@ -581,7 +581,7 @@ class ParameterizedLoggingTest implements RewriteTest {
               """,
             """
               import org.slf4j.Logger;
-              
+
               class Test {
                   static void method(Logger logger) {
                       String one = "one";
@@ -594,32 +594,35 @@ class ParameterizedLoggingTest implements RewriteTest {
           )
         );
     }
-}
+
     @Test
     @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/159")
     void parameterizedWithMarker() {
-    rewriteRun(
-        spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger info(..)", false)),
-        // language=java
-        java(
+        rewriteRun(
+          spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger info(..)", false)),
+          // language=java
+          java(
             """
-            import org.slf4j.Logger;
-            import org.slf4j.Marker;
-            class Test {
-                static void method(Logger logger, Marker marker, String name) {
-                    logger.info(marker, "Hello " + name + ", nice to meet you " + name);
-                }
-            }
-            """,
+              import org.slf4j.Logger;
+              import org.slf4j.Marker;
+
+              class Test {
+                  static void method(Logger logger, Marker marker, String name) {
+                      logger.info(marker, "Hello " + name + ", nice to meet you " + name);
+                  }
+              }
+              """,
             """
-            import org.slf4j.Logger;
-            import org.slf4j.Marker;
-            class Test {
-                static void method(Logger logger, Marker marker, String name) {
-                    logger.info(marker, "Hello {}, nice to meet you {}", name, name);
-                }
-            }
-            """
-        )
-    );
+               import org.slf4j.Logger;
+               import org.slf4j.Marker;
+
+               class Test {
+                   static void method(Logger logger, Marker marker, String name) {
+                       logger.info(marker, "Hello {}, nice to meet you {}", name, name);
+                   }
+               }
+               """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -595,3 +595,31 @@ class ParameterizedLoggingTest implements RewriteTest {
         );
     }
 }
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/159")
+    void parameterizedWithMarker() {
+    rewriteRun(
+        spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger info(..)", false)),
+        // language=java
+        java(
+            """
+            import org.slf4j.Logger;
+            import org.slf4j.Marker;
+            class Test {
+                static void method(Logger logger, Marker marker, String name) {
+                    logger.info(marker, "Hello " + name + ", nice to meet you " + name);
+                }
+            }
+            """,
+            """
+            import org.slf4j.Logger;
+            import org.slf4j.Marker;
+            class Test {
+                static void method(Logger logger, Marker marker, String name) {
+                    logger.info(marker, "Hello {}, nice to meet you {}", name, name);
+                }
+            }
+            """
+        )
+    );
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
Explanation of Changes:
Argument Handling:

A check is added to detect if the Marker argument is present.
If a Marker is detected, it ensures that it remains as the first argument.
Argument Reordering:

After constructing the new argument list, if a Marker is detected, it is added at the beginning of the newArgList.
Test Adjustments:

Ensure that your tests verify that the Marker argument remains in the correct position and that the logging message is parameterized correctly.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
- Fixes #159 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
