### PR TITLE
Add handling of convertion JUL to slf4j calls with Throwable; #155

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/slf4j/JulToSlf4jLambdaSupplierWithThrowable.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/JulToSlf4jLambdaSupplierWithThrowable.java
@@ -24,8 +24,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 @RecipeDescriptor(
-        name = "Replace JUL active Level check with corresponding SLF4J method calls",
-        description = "Replace calls to `Logger.isLoggable(Level)` with the corresponding SLF4J method calls."
+        name = "Replace JUL `log(Level, Throwable, Supplier<String>)` with corresponding SLF4J method calls",
+        description = "Replace calls to `Logger.log(Level, Throwable, Supplier<String>)` with the corresponding SLF4J method calls."
 )
 public class JulToSlf4jLambdaSupplierWithThrowable {
     @RecipeDescriptor(

--- a/src/main/java/org/openrewrite/java/logging/slf4j/JulToSlf4jLambdaSupplierWithThrowable.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/JulToSlf4jLambdaSupplierWithThrowable.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.logging.slf4j;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.openrewrite.java.template.RecipeDescriptor;
+
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@RecipeDescriptor(
+        name = "Replace JUL active Level check with corresponding SLF4J method calls",
+        description = "Replace calls to `Logger.isLoggable(Level)` with the corresponding SLF4J method calls."
+)
+public class JulToSlf4jLambdaSupplierWithThrowable {
+    @RecipeDescriptor(
+            name = "Replace JUL `logger.log(Level.FINEST, e, Supplier<String>)` with SLF4J's `Logger.atTrace().log(Supplier<String>)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.FINEST, e, Supplier<String>)` with `org.slf4j.Logger.atTrace().log(Supplier<String>)`."
+    )
+    public static class JulToSlf4jSupplierFinest {
+        @BeforeTemplate
+        void before(Logger logger, Supplier<String> supplier, Throwable e) {
+            logger.log(Level.FINEST, e, supplier);
+        }
+
+        @AfterTemplate
+        void after(org.slf4j.Logger logger, Supplier<String> supplier, Throwable e) {
+            logger.atTrace().setCause(e).log(supplier);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace JUL `logger.log(Level.FINER, e, Supplier<String>)` with SLF4J's `Logger.atTrace().log(Supplier<String>)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.FINER, e, Supplier<String>)` with `org.slf4j.Logger.atTrace().log(Supplier<String>)`."
+    )
+    public static class JulToSlf4jSupplierFiner {
+        @BeforeTemplate
+        void before(Logger logger, Supplier<String> supplier, Throwable e) {
+            logger.log(Level.FINER, e, supplier);
+        }
+
+        @AfterTemplate
+        void after(org.slf4j.Logger logger, Supplier<String> supplier, Throwable e) {
+            logger.atTrace().setCause(e).log(supplier);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace JUL `logger.log(Level.FINE, e, Supplier<String>)` with SLF4J's `Logger.atDebug().log(Supplier<String>)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.FINE, e, Supplier<String>)` with `org.slf4j.Logger.atDebug().log(Supplier<String>)`."
+    )
+    public static class JulToSlf4jSupplierFine {
+        @BeforeTemplate
+        void before(Logger logger, Supplier<String> supplier, Throwable e) {
+            logger.log(Level.FINE, e, supplier);
+        }
+
+        @AfterTemplate
+        void after(org.slf4j.Logger logger, Supplier<String> supplier, Throwable e) {
+            logger.atDebug().setCause(e).log(supplier);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace JUL `logger.log(Level.CONFIG, e, Supplier<String>)` with SLF4J's `Logger.atInfo().log(Supplier<String>)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.CONFIG, e, Supplier<String>)` with `org.slf4j.Logger.atInfo().log(Supplier<String>)`."
+    )
+    public static class JulToSlf4jSupplierConfig {
+        @BeforeTemplate
+        void before(Logger logger, Supplier<String> supplier, Throwable e) {
+            logger.log(Level.CONFIG, e, supplier);
+        }
+
+        @AfterTemplate
+        void after(org.slf4j.Logger logger, Supplier<String> supplier, Throwable e) {
+            logger.atInfo().setCause(e).log(supplier);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace JUL `logger.log(Level.INFO, e, Supplier<String>)` with SLF4J's `Logger.atInfo().log(Supplier<String>)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.INFO, e, Supplier<String>)` with `org.slf4j.Logger.atInfo().log(Supplier<String>)`."
+    )
+    public static class JulToSlf4jSupplierInfo {
+        @BeforeTemplate
+        void before(Logger logger, Supplier<String> supplier, Throwable e) {
+            logger.log(Level.INFO, e, supplier);
+        }
+
+        @AfterTemplate
+        void after(org.slf4j.Logger logger, Supplier<String> supplier, Throwable e) {
+            logger.atInfo().setCause(e).log(supplier);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace JUL `logger.log(Level.WARNING, e, Supplier<String>)` with SLF4J's `Logger.atWarn().log(Supplier<String>)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.WARNING, e, Supplier<String>)` with `org.slf4j.Logger.atWarn().log(Supplier<String>)`."
+    )
+    public static class JulToSlf4jSupplierWarning {
+        @BeforeTemplate
+        void before(Logger logger, Supplier<String> supplier, Throwable e) {
+            logger.log(Level.WARNING, e, supplier);
+        }
+
+        @AfterTemplate
+        void after(org.slf4j.Logger logger, Supplier<String> supplier, Throwable e) {
+            logger.atWarn().setCause(e).log(supplier);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace JUL `logger.log(Level.SEVERE, e, Supplier<String>)` with SLF4J's `Logger.atError().log(Supplier<String>)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.SEVERE, e, Supplier<String>)` with `org.slf4j.Logger.atError().log(Supplier<String>)`."
+    )
+    public static class JulToSlf4jSupplierSevere {
+        @BeforeTemplate
+        void before(Logger logger, Supplier<String> supplier, Throwable e) {
+            logger.log(Level.SEVERE, e, supplier);
+        }
+
+        @AfterTemplate
+        void after(org.slf4j.Logger logger, Supplier<String> supplier, Throwable e) {
+            logger.atError().setCause(e).log(supplier);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace JUL `logger.log(Level.ALL, e, Supplier<String>)` with SLF4J's `Logger.atTrace().log(Supplier<String>)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.ALL, e, Supplier<String>)` with `org.slf4j.Logger.atTrace().log(Supplier<String>)`."
+    )
+    public static class JulToSlf4jSupplierAll {
+        @BeforeTemplate
+        void before(Logger logger, Supplier<String> supplier, Throwable e) {
+            logger.log(Level.ALL, e, supplier);
+        }
+
+        @AfterTemplate
+        void after(org.slf4j.Logger logger, Supplier<String> supplier, Throwable e) {
+            logger.atTrace().setCause(e).log(supplier);
+        }
+    }
+
+}

--- a/src/main/java/org/openrewrite/java/logging/slf4j/JulToSlf4jLambdaSupplierWithThrowable.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/JulToSlf4jLambdaSupplierWithThrowable.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 public class JulToSlf4jLambdaSupplierWithThrowable {
     @RecipeDescriptor(
             name = "Replace JUL `logger.log(Level.FINEST, e, Supplier<String>)` with SLF4J's `Logger.atTrace().log(Supplier<String>)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.FINEST, e, Supplier<String>)` with `org.slf4j.Logger.atTrace().log(Supplier<String>)`."
+            description = "Replace calls to `java.util.logging.Logger.log(Level.FINEST, e, Supplier<String>)` with `org.slf4j.Logger.atTrace().log(Supplier<String>)`."
     )
     public static class JulToSlf4jSupplierFinest {
         @BeforeTemplate
@@ -46,7 +46,7 @@ public class JulToSlf4jLambdaSupplierWithThrowable {
 
     @RecipeDescriptor(
             name = "Replace JUL `logger.log(Level.FINER, e, Supplier<String>)` with SLF4J's `Logger.atTrace().log(Supplier<String>)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.FINER, e, Supplier<String>)` with `org.slf4j.Logger.atTrace().log(Supplier<String>)`."
+            description = "Replace calls to `java.util.logging.Logger.log(Level.FINER, e, Supplier<String>)` with `org.slf4j.Logger.atTrace().log(Supplier<String>)`."
     )
     public static class JulToSlf4jSupplierFiner {
         @BeforeTemplate
@@ -62,7 +62,7 @@ public class JulToSlf4jLambdaSupplierWithThrowable {
 
     @RecipeDescriptor(
             name = "Replace JUL `logger.log(Level.FINE, e, Supplier<String>)` with SLF4J's `Logger.atDebug().log(Supplier<String>)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.FINE, e, Supplier<String>)` with `org.slf4j.Logger.atDebug().log(Supplier<String>)`."
+            description = "Replace calls to `java.util.logging.Logger.log(Level.FINE, e, Supplier<String>)` with `org.slf4j.Logger.atDebug().log(Supplier<String>)`."
     )
     public static class JulToSlf4jSupplierFine {
         @BeforeTemplate
@@ -78,7 +78,7 @@ public class JulToSlf4jLambdaSupplierWithThrowable {
 
     @RecipeDescriptor(
             name = "Replace JUL `logger.log(Level.CONFIG, e, Supplier<String>)` with SLF4J's `Logger.atInfo().log(Supplier<String>)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.CONFIG, e, Supplier<String>)` with `org.slf4j.Logger.atInfo().log(Supplier<String>)`."
+            description = "Replace calls to `java.util.logging.Logger.log(Level.CONFIG, e, Supplier<String>)` with `org.slf4j.Logger.atInfo().log(Supplier<String>)`."
     )
     public static class JulToSlf4jSupplierConfig {
         @BeforeTemplate
@@ -94,7 +94,7 @@ public class JulToSlf4jLambdaSupplierWithThrowable {
 
     @RecipeDescriptor(
             name = "Replace JUL `logger.log(Level.INFO, e, Supplier<String>)` with SLF4J's `Logger.atInfo().log(Supplier<String>)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.INFO, e, Supplier<String>)` with `org.slf4j.Logger.atInfo().log(Supplier<String>)`."
+            description = "Replace calls to `java.util.logging.Logger.log(Level.INFO, e, Supplier<String>)` with `org.slf4j.Logger.atInfo().log(Supplier<String>)`."
     )
     public static class JulToSlf4jSupplierInfo {
         @BeforeTemplate
@@ -110,7 +110,7 @@ public class JulToSlf4jLambdaSupplierWithThrowable {
 
     @RecipeDescriptor(
             name = "Replace JUL `logger.log(Level.WARNING, e, Supplier<String>)` with SLF4J's `Logger.atWarn().log(Supplier<String>)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.WARNING, e, Supplier<String>)` with `org.slf4j.Logger.atWarn().log(Supplier<String>)`."
+            description = "Replace calls to `java.util.logging.Logger.log(Level.WARNING, e, Supplier<String>)` with `org.slf4j.Logger.atWarn().log(Supplier<String>)`."
     )
     public static class JulToSlf4jSupplierWarning {
         @BeforeTemplate
@@ -126,7 +126,7 @@ public class JulToSlf4jLambdaSupplierWithThrowable {
 
     @RecipeDescriptor(
             name = "Replace JUL `logger.log(Level.SEVERE, e, Supplier<String>)` with SLF4J's `Logger.atError().log(Supplier<String>)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.SEVERE, e, Supplier<String>)` with `org.slf4j.Logger.atError().log(Supplier<String>)`."
+            description = "Replace calls to `java.util.logging.Logger.log(Level.SEVERE, e, Supplier<String>)` with `org.slf4j.Logger.atError().log(Supplier<String>)`."
     )
     public static class JulToSlf4jSupplierSevere {
         @BeforeTemplate
@@ -142,7 +142,7 @@ public class JulToSlf4jLambdaSupplierWithThrowable {
 
     @RecipeDescriptor(
             name = "Replace JUL `logger.log(Level.ALL, e, Supplier<String>)` with SLF4J's `Logger.atTrace().log(Supplier<String>)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.ALL, e, Supplier<String>)` with `org.slf4j.Logger.atTrace().log(Supplier<String>)`."
+            description = "Replace calls to `java.util.logging.Logger.log(Level.ALL, e, Supplier<String>)` with `org.slf4j.Logger.atTrace().log(Supplier<String>)`."
     )
     public static class JulToSlf4jSupplierAll {
         @BeforeTemplate

--- a/src/main/java/org/openrewrite/java/logging/slf4j/JulToSlf4jSimpleCallsWithThrowable.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/JulToSlf4jSimpleCallsWithThrowable.java
@@ -28,8 +28,8 @@ import java.util.logging.Logger;
 )
 public class JulToSlf4jSimpleCallsWithThrowable {
     @RecipeDescriptor(
-            name = "Replace JUL `logger.log(Level.FINEST, e, String message)` with SLF4J's `Logger.trace(message, e)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.FINEST, e, String message)` with `org.slf4j.Logger.trace(message, e)`."
+            name = "Replace JUL `logger.log(Level.FINEST, String message, Throwable e)` with SLF4J's `Logger.trace(message, e)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.FINEST, String message, Throwable e)` with `org.slf4j.Logger.trace(message, e)`."
     )
     public static class JulToSlf4jSupplierFinest {
         @BeforeTemplate
@@ -44,8 +44,8 @@ public class JulToSlf4jSimpleCallsWithThrowable {
     }
 
     @RecipeDescriptor(
-            name = "Replace JUL `logger.log(Level.FINER, e, String message)` with SLF4J's `Logger.trace(message, e)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.FINER, e, String message)` with `org.slf4j.Logger.trace(message, e)`."
+            name = "Replace JUL `logger.log(Level.FINER, String message, Throwable e)` with SLF4J's `Logger.trace(message, e)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.FINER, String message, Throwable e)` with `org.slf4j.Logger.trace(message, e)`."
     )
     public static class JulToSlf4jSupplierFiner {
         @BeforeTemplate
@@ -60,8 +60,8 @@ public class JulToSlf4jSimpleCallsWithThrowable {
     }
 
     @RecipeDescriptor(
-            name = "Replace JUL `logger.log(Level.FINE, e, String message)` with SLF4J's `Logger.debug(message, e)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.FINE, e, String message)` with `org.slf4j.Logger.debug(message, e)`."
+            name = "Replace JUL `logger.log(Level.FINE, String message, Throwable e)` with SLF4J's `Logger.debug(message, e)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.FINE, String message, Throwable e)` with `org.slf4j.Logger.debug(message, e)`."
     )
     public static class JulToSlf4jSupplierFine {
         @BeforeTemplate
@@ -76,8 +76,8 @@ public class JulToSlf4jSimpleCallsWithThrowable {
     }
 
     @RecipeDescriptor(
-            name = "Replace JUL `logger.log(Level.CONFIG, e, String message)` with SLF4J's `Logger.info(message, e)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.CONFIG, e, String message)` with `org.slf4j.Logger.info(message, e)`."
+            name = "Replace JUL `logger.log(Level.CONFIG, String message, Throwable e)` with SLF4J's `Logger.info(message, e)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.CONFIG, String message, Throwable e)` with `org.slf4j.Logger.info(message, e)`."
     )
     public static class JulToSlf4jSupplierConfig {
         @BeforeTemplate
@@ -92,8 +92,8 @@ public class JulToSlf4jSimpleCallsWithThrowable {
     }
 
     @RecipeDescriptor(
-            name = "Replace JUL `logger.log(Level.INFO, e, String message)` with SLF4J's `Logger.info(message, e)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.INFO, e, String message)` with `org.slf4j.Logger.info(message, e)`."
+            name = "Replace JUL `logger.log(Level.INFO, String message, Throwable e)` with SLF4J's `Logger.info(message, e)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.INFO, String message, Throwable e)` with `org.slf4j.Logger.info(message, e)`."
     )
     public static class JulToSlf4jSupplierInfo {
         @BeforeTemplate
@@ -108,8 +108,8 @@ public class JulToSlf4jSimpleCallsWithThrowable {
     }
 
     @RecipeDescriptor(
-            name = "Replace JUL `logger.log(Level.WARNING, e, String message)` with SLF4J's `Logger.warn(message, e)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.WARNING, e, String message)` with `org.slf4j.Logger.warn(message, e)`."
+            name = "Replace JUL `logger.log(Level.WARNING, String message, Throwable e)` with SLF4J's `Logger.warn(message, e)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.WARNING, String message, Throwable e)` with `org.slf4j.Logger.warn(message, e)`."
     )
     public static class JulToSlf4jSupplierWarning {
         @BeforeTemplate
@@ -124,8 +124,8 @@ public class JulToSlf4jSimpleCallsWithThrowable {
     }
 
     @RecipeDescriptor(
-            name = "Replace JUL `logger.log(Level.SEVERE, e, String message)` with SLF4J's `Logger.error(message, e)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.SEVERE, e, String message)` with `org.slf4j.Logger.error(message, e)`."
+            name = "Replace JUL `logger.log(Level.SEVERE, String message, Throwable e)` with SLF4J's `Logger.error(message, e)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.SEVERE, String message, Throwable e)` with `org.slf4j.Logger.error(message, e)`."
     )
     public static class JulToSlf4jSupplierSevere {
         @BeforeTemplate
@@ -140,8 +140,8 @@ public class JulToSlf4jSimpleCallsWithThrowable {
     }
 
     @RecipeDescriptor(
-            name = "Replace JUL `logger.log(Level.ALL, e, String message)` with SLF4J's `Logger.trace(message, e)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.ALL, e, String message)` with `org.slf4j.Logger.trace(message, e)`."
+            name = "Replace JUL `logger.log(Level.ALL, String message, Throwable e)` with SLF4J's `Logger.trace(message, e)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.ALL, String message, Throwable e)` with `org.slf4j.Logger.trace(message, e)`."
     )
     public static class JulToSlf4jSupplierAll {
         @BeforeTemplate

--- a/src/main/java/org/openrewrite/java/logging/slf4j/JulToSlf4jSimpleCallsWithThrowable.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/JulToSlf4jSimpleCallsWithThrowable.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.logging.slf4j;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import org.openrewrite.java.template.RecipeDescriptor;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@RecipeDescriptor(
+        name = "Replace JUL active Level check with corresponding SLF4J method calls",
+        description = "Replace calls to `Logger.isLoggable(Level)` with the corresponding SLF4J method calls."
+)
+public class JulToSlf4jSimpleCallsWithThrowable {
+    @RecipeDescriptor(
+            name = "Replace JUL `logger.log(Level.FINEST, e, String message)` with SLF4J's `Logger.trace(message, e)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.FINEST, e, String message)` with `org.slf4j.Logger.trace(message, e)`."
+    )
+    public static class JulToSlf4jSupplierFinest {
+        @BeforeTemplate
+        void before(Logger logger, String message, Throwable e) {
+            logger.log(Level.FINEST, message, e);
+        }
+
+        @AfterTemplate
+        void after(org.slf4j.Logger logger, String message, Throwable e) {
+            logger.trace(message, e);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace JUL `logger.log(Level.FINER, e, String message)` with SLF4J's `Logger.trace(message, e)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.FINER, e, String message)` with `org.slf4j.Logger.trace(message, e)`."
+    )
+    public static class JulToSlf4jSupplierFiner {
+        @BeforeTemplate
+        void before(Logger logger, String message, Throwable e) {
+            logger.log(Level.FINER, message, e);
+        }
+
+        @AfterTemplate
+        void after(org.slf4j.Logger logger, String message, Throwable e) {
+            logger.trace(message, e);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace JUL `logger.log(Level.FINE, e, String message)` with SLF4J's `Logger.debug(message, e)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.FINE, e, String message)` with `org.slf4j.Logger.debug(message, e)`."
+    )
+    public static class JulToSlf4jSupplierFine {
+        @BeforeTemplate
+        void before(Logger logger, String message, Throwable e) {
+            logger.log(Level.FINE, message, e);
+        }
+
+        @AfterTemplate
+        void after(org.slf4j.Logger logger, String message, Throwable e) {
+            logger.debug(message, e);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace JUL `logger.log(Level.CONFIG, e, String message)` with SLF4J's `Logger.info(message, e)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.CONFIG, e, String message)` with `org.slf4j.Logger.info(message, e)`."
+    )
+    public static class JulToSlf4jSupplierConfig {
+        @BeforeTemplate
+        void before(Logger logger, String message, Throwable e) {
+            logger.log(Level.CONFIG, message, e);
+        }
+
+        @AfterTemplate
+        void after(org.slf4j.Logger logger, String message, Throwable e) {
+            logger.info(message, e);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace JUL `logger.log(Level.INFO, e, String message)` with SLF4J's `Logger.info(message, e)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.INFO, e, String message)` with `org.slf4j.Logger.info(message, e)`."
+    )
+    public static class JulToSlf4jSupplierInfo {
+        @BeforeTemplate
+        void before(Logger logger, String message, Throwable e) {
+            logger.log(Level.INFO, message, e);
+        }
+
+        @AfterTemplate
+        void after(org.slf4j.Logger logger, String message, Throwable e) {
+            logger.info(message, e);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace JUL `logger.log(Level.WARNING, e, String message)` with SLF4J's `Logger.warn(message, e)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.WARNING, e, String message)` with `org.slf4j.Logger.warn(message, e)`."
+    )
+    public static class JulToSlf4jSupplierWarning {
+        @BeforeTemplate
+        void before(Logger logger, String message, Throwable e) {
+            logger.log(Level.WARNING, message, e);
+        }
+
+        @AfterTemplate
+        void after(org.slf4j.Logger logger, String message, Throwable e) {
+            logger.warn(message, e);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace JUL `logger.log(Level.SEVERE, e, String message)` with SLF4J's `Logger.error(message, e)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.SEVERE, e, String message)` with `org.slf4j.Logger.error(message, e)`."
+    )
+    public static class JulToSlf4jSupplierSevere {
+        @BeforeTemplate
+        void before(Logger logger, String message, Throwable e) {
+            logger.log(Level.SEVERE, message, e);
+        }
+
+        @AfterTemplate
+        void after(org.slf4j.Logger logger, String message, Throwable e) {
+            logger.error(message, e);
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace JUL `logger.log(Level.ALL, e, String message)` with SLF4J's `Logger.trace(message, e)`",
+            description = "Replace calls to `java.util.logging.logger.log(Level.ALL, e, String message)` with `org.slf4j.Logger.trace(message, e)`."
+    )
+    public static class JulToSlf4jSupplierAll {
+        @BeforeTemplate
+        void before(Logger logger, String message, Throwable e) {
+            logger.log(Level.ALL, message, e);
+        }
+
+        @AfterTemplate
+        void after(org.slf4j.Logger logger, String message, Throwable e) {
+            logger.trace(message, e);
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/java/logging/slf4j/JulToSlf4jSimpleCallsWithThrowable.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/JulToSlf4jSimpleCallsWithThrowable.java
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
 public class JulToSlf4jSimpleCallsWithThrowable {
     @RecipeDescriptor(
             name = "Replace JUL `logger.log(Level.FINEST, String message, Throwable e)` with SLF4J's `Logger.trace(message, e)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.FINEST, String message, Throwable e)` with `org.slf4j.Logger.trace(message, e)`."
+            description = "Replace calls to `java.util.logging.Logger.log(Level.FINEST, String message, Throwable e)` with `org.slf4j.Logger.trace(message, e)`."
     )
     public static class JulToSlf4jSupplierFinest {
         @BeforeTemplate
@@ -45,7 +45,7 @@ public class JulToSlf4jSimpleCallsWithThrowable {
 
     @RecipeDescriptor(
             name = "Replace JUL `logger.log(Level.FINER, String message, Throwable e)` with SLF4J's `Logger.trace(message, e)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.FINER, String message, Throwable e)` with `org.slf4j.Logger.trace(message, e)`."
+            description = "Replace calls to `java.util.logging.Logger.log(Level.FINER, String message, Throwable e)` with `org.slf4j.Logger.trace(message, e)`."
     )
     public static class JulToSlf4jSupplierFiner {
         @BeforeTemplate
@@ -61,7 +61,7 @@ public class JulToSlf4jSimpleCallsWithThrowable {
 
     @RecipeDescriptor(
             name = "Replace JUL `logger.log(Level.FINE, String message, Throwable e)` with SLF4J's `Logger.debug(message, e)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.FINE, String message, Throwable e)` with `org.slf4j.Logger.debug(message, e)`."
+            description = "Replace calls to `java.util.logging.Logger.log(Level.FINE, String message, Throwable e)` with `org.slf4j.Logger.debug(message, e)`."
     )
     public static class JulToSlf4jSupplierFine {
         @BeforeTemplate
@@ -77,7 +77,7 @@ public class JulToSlf4jSimpleCallsWithThrowable {
 
     @RecipeDescriptor(
             name = "Replace JUL `logger.log(Level.CONFIG, String message, Throwable e)` with SLF4J's `Logger.info(message, e)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.CONFIG, String message, Throwable e)` with `org.slf4j.Logger.info(message, e)`."
+            description = "Replace calls to `java.util.logging.Logger.log(Level.CONFIG, String message, Throwable e)` with `org.slf4j.Logger.info(message, e)`."
     )
     public static class JulToSlf4jSupplierConfig {
         @BeforeTemplate
@@ -93,7 +93,7 @@ public class JulToSlf4jSimpleCallsWithThrowable {
 
     @RecipeDescriptor(
             name = "Replace JUL `logger.log(Level.INFO, String message, Throwable e)` with SLF4J's `Logger.info(message, e)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.INFO, String message, Throwable e)` with `org.slf4j.Logger.info(message, e)`."
+            description = "Replace calls to `java.util.logging.Logger.log(Level.INFO, String message, Throwable e)` with `org.slf4j.Logger.info(message, e)`."
     )
     public static class JulToSlf4jSupplierInfo {
         @BeforeTemplate
@@ -109,7 +109,7 @@ public class JulToSlf4jSimpleCallsWithThrowable {
 
     @RecipeDescriptor(
             name = "Replace JUL `logger.log(Level.WARNING, String message, Throwable e)` with SLF4J's `Logger.warn(message, e)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.WARNING, String message, Throwable e)` with `org.slf4j.Logger.warn(message, e)`."
+            description = "Replace calls to `java.util.logging.Logger.log(Level.WARNING, String message, Throwable e)` with `org.slf4j.Logger.warn(message, e)`."
     )
     public static class JulToSlf4jSupplierWarning {
         @BeforeTemplate
@@ -125,7 +125,7 @@ public class JulToSlf4jSimpleCallsWithThrowable {
 
     @RecipeDescriptor(
             name = "Replace JUL `logger.log(Level.SEVERE, String message, Throwable e)` with SLF4J's `Logger.error(message, e)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.SEVERE, String message, Throwable e)` with `org.slf4j.Logger.error(message, e)`."
+            description = "Replace calls to `java.util.logging.Logger.log(Level.SEVERE, String message, Throwable e)` with `org.slf4j.Logger.error(message, e)`."
     )
     public static class JulToSlf4jSupplierSevere {
         @BeforeTemplate
@@ -141,7 +141,7 @@ public class JulToSlf4jSimpleCallsWithThrowable {
 
     @RecipeDescriptor(
             name = "Replace JUL `logger.log(Level.ALL, String message, Throwable e)` with SLF4J's `Logger.trace(message, e)`",
-            description = "Replace calls to `java.util.logging.logger.log(Level.ALL, String message, Throwable e)` with `org.slf4j.Logger.trace(message, e)`."
+            description = "Replace calls to `java.util.logging.Logger.log(Level.ALL, String message, Throwable e)` with `org.slf4j.Logger.trace(message, e)`."
     )
     public static class JulToSlf4jSupplierAll {
         @BeforeTemplate

--- a/src/main/java/org/openrewrite/java/logging/slf4j/JulToSlf4jSimpleCallsWithThrowable.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/JulToSlf4jSimpleCallsWithThrowable.java
@@ -23,8 +23,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 @RecipeDescriptor(
-        name = "Replace JUL active Level check with corresponding SLF4J method calls",
-        description = "Replace calls to `Logger.isLoggable(Level)` with the corresponding SLF4J method calls."
+        name = "Replace JUL `log(Level, String, Throwable)` with corresponding SLF4J method calls",
+        description = "Replace calls to `Logger.log(Level, String, Throwable)` with the corresponding SLF4J method calls."
 )
 public class JulToSlf4jSimpleCallsWithThrowable {
     @RecipeDescriptor(

--- a/src/main/resources/META-INF/rewrite/slf4j.yml
+++ b/src/main/resources/META-INF/rewrite/slf4j.yml
@@ -190,6 +190,8 @@ recipeList:
   - org.openrewrite.java.logging.slf4j.JulIsLoggableToIsEnabledRecipes
   - org.openrewrite.java.logging.slf4j.JulParameterizedArguments
   - org.openrewrite.java.logging.slf4j.JulToSlf4jLambdaSupplierRecipes
+  - org.openrewrite.java.logging.slf4j.JulToSlf4jLambdaSupplierWithThrowableRecipes
+  - org.openrewrite.java.logging.slf4j.JulToSlf4jSimpleCallsWithThrowableRecipes
   - org.openrewrite.java.logging.slf4j.JulLevelAllToTraceRecipe
   - org.openrewrite.java.logging.log4j.JulToLog4j
   - org.openrewrite.java.logging.slf4j.Log4j2ToSlf4j1

--- a/src/test/java/org/openrewrite/java/logging/slf4j/JulToSlf4jTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/JulToSlf4jTest.java
@@ -101,6 +101,51 @@ class JulToSlf4jTest implements RewriteTest {
         );
     }
 
+    @DocumentExample
+    @Test
+    void simpleLoggerCallsWithThrowable() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import java.util.logging.Level;
+              import java.util.logging.Logger;
+
+              class Test {
+                  void method(Logger logger, Throwable e) {
+                      logger.log(Level.FINEST, "finest", e);
+                      logger.log(Level.FINER, "finer", e);
+                      logger.log(Level.FINE, "fine", e);
+                      logger.log(Level.CONFIG, "config", e);
+                      logger.log(Level.INFO, "info", e);
+                      logger.log(Level.WARNING, "warning", e);
+                      logger.log(Level.SEVERE, "severe", e);
+
+                      logger.log(Level.ALL, "all", e);
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+
+              class Test {
+                  void method(Logger logger, Throwable e) {
+                      logger.trace("finest", e);
+                      logger.trace("finer", e);
+                      logger.debug("fine", e);
+                      logger.info("config", e);
+                      logger.info("info", e);
+                      logger.warn("warning", e);
+                      logger.error("severe", e);
+
+                      logger.trace("all", e);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void supplierLoggerCalls() {
         rewriteRun(
@@ -155,6 +200,51 @@ class JulToSlf4jTest implements RewriteTest {
                       logger.atError().log(() -> "severe");
 
                       logger.atTrace().log(() -> "all");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void supplierLoggerCallsWithThrowable() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.builder().methodInvocations(false).build()),
+          // language=java
+          java(
+            """
+              import java.util.logging.Level;
+              import java.util.logging.Logger;
+
+              class Test {
+                  void method(Logger logger, Throwable e) {
+                      logger.log(Level.FINEST, e, () -> "finest");
+                      logger.log(Level.FINER, e, () -> "finer");
+                      logger.log(Level.FINE, e, () -> "fine");
+                      logger.log(Level.CONFIG, e, () -> "config");
+                      logger.log(Level.INFO, e, () -> "info");
+                      logger.log(Level.WARNING, e, () -> "warning");
+                      logger.log(Level.SEVERE, e, () -> "severe");
+
+                      logger.log(Level.ALL, e, () -> "all");
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+
+              class Test {
+                  void method(Logger logger, Throwable e) {
+                      logger.atTrace().setCause(e).log(() -> "finest");
+                      logger.atTrace().setCause(e).log(() -> "finer");
+                      logger.atDebug().setCause(e).log(() -> "fine");
+                      logger.atInfo().setCause(e).log(() -> "config");
+                      logger.atInfo().setCause(e).log(() -> "info");
+                      logger.atWarn().setCause(e).log(() -> "warning");
+                      logger.atError().setCause(e).log(() -> "severe");
+
+                      logger.atTrace().setCause(e).log(() -> "all");
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/logging/slf4j/JulToSlf4jTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/JulToSlf4jTest.java
@@ -101,7 +101,6 @@ class JulToSlf4jTest implements RewriteTest {
         );
     }
 
-    @DocumentExample
     @Test
     void simpleLoggerCallsWithThrowable() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?
Added conversion from JUL to slf4j calls that have Throwable as parameter included

## What's your motivation?
Continuation of #155 and PR: https://github.com/openrewrite/rewrite-logging-frameworks/pull/160

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
