### PR TITLE
Fix Log4jToSlf4 Single Statement If `Could not parse as Java`

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/ParameterizedLogging.java
+++ b/src/main/java/org/openrewrite/java/logging/ParameterizedLogging.java
@@ -98,7 +98,9 @@ public class ParameterizedLogging extends Recipe {
                             }
                             return message;
                         });
-                        m = JavaTemplate.builder(escapeDollarSign(messageBuilder.toString()))
+                        String code = escapeDollarSign(messageBuilder.toString());
+                        m = JavaTemplate.builder(code)
+                                .doBeforeParseTemplate(System.out::println) // TODO Remove again
                                 .contextSensitive()
                                 .build()
                                 .apply(new Cursor(getCursor().getParent(), m), m.getCoordinates().replaceArguments(), newArgList.toArray());

--- a/src/test/java/org/openrewrite/java/logging/slf4j/Log4j2ToSlf4j1Test.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/Log4j2ToSlf4j1Test.java
@@ -46,7 +46,7 @@ class Log4j2ToSlf4j1Test implements RewriteTest {
           java(
             """
               import org.apache.logging.log4j.Logger;
-
+              
               class Test {
                   static void method(Logger logger) {
                       logger.fatal("uh oh");
@@ -55,7 +55,7 @@ class Log4j2ToSlf4j1Test implements RewriteTest {
               """,
             """
               import org.slf4j.Logger;
-
+              
               class Test {
                   static void method(Logger logger) {
                       logger.error("uh oh");
@@ -72,37 +72,37 @@ class Log4j2ToSlf4j1Test implements RewriteTest {
         rewriteRun(
           java(
             """
-             import org.apache.logging.log4j.Logger;
-             import org.apache.logging.log4j.LogManager;
-
-             class Test {
-                 private static final Logger LOGGER = LogManager.getLogger(Test.class);
-                 private static final Logger ROOT_LOGGER = LogManager.getRootLogger();
-
-                 public static void main(String[] args) {
-                     if (LOGGER.isDebugEnabled()) {
-                         LOGGER.debug("logger message");
-                     }
-                     ROOT_LOGGER.info("root logger message");
-                 }
-             }
-             """,
+              import org.apache.logging.log4j.Logger;
+              import org.apache.logging.log4j.LogManager;
+              
+              class Test {
+                  private static final Logger LOGGER = LogManager.getLogger(Test.class);
+                  private static final Logger ROOT_LOGGER = LogManager.getRootLogger();
+              
+                  public static void main(String[] args) {
+                      if (LOGGER.isDebugEnabled()) {
+                          LOGGER.debug("logger message");
+                      }
+                      ROOT_LOGGER.info("root logger message");
+                  }
+              }
+              """,
             """
-             import org.slf4j.Logger;
-             import org.slf4j.LoggerFactory;
-
-             class Test {
-                 private static final Logger LOGGER = LoggerFactory.getLogger(Test.class);
-                 private static final Logger ROOT_LOGGER = LoggerFactory.getRootLogger();
-
-                 public static void main(String[] args) {
-                     if (LOGGER.isDebugEnabled()) {
-                         LOGGER.debug("logger message");
-                     }
-                     ROOT_LOGGER.info("root logger message");
-                 }
-             }
-             """
+              import org.slf4j.Logger;
+              import org.slf4j.LoggerFactory;
+              
+              class Test {
+                  private static final Logger LOGGER = LoggerFactory.getLogger(Test.class);
+                  private static final Logger ROOT_LOGGER = LoggerFactory.getRootLogger();
+              
+                  public static void main(String[] args) {
+                      if (LOGGER.isDebugEnabled()) {
+                          LOGGER.debug("logger message");
+                      }
+                      ROOT_LOGGER.info("root logger message");
+                  }
+              }
+              """
           )
         );
     }
@@ -115,7 +115,7 @@ class Log4j2ToSlf4j1Test implements RewriteTest {
           java(
             """
               import lombok.extern.log4j.Log4j;
-
+              
               @Log4j
               class Test {
                   void method() {
@@ -125,7 +125,7 @@ class Log4j2ToSlf4j1Test implements RewriteTest {
               """,
             """
               import lombok.extern.slf4j.Slf4j;
-
+              
               @Slf4j
               class Test {
                   void method() {
@@ -141,45 +141,42 @@ class Log4j2ToSlf4j1Test implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/185")
     void singleStatementIf() {
         rewriteRun(
-          spec -> spec.recipe(Environment.builder()
-            .scanRuntimeClasspath("org.openrewrite.java.logging")
-            .build()
-            .activateRecipes("org.openrewrite.java.logging.slf4j.Log4j2ToSlf4j1")),
+          //language=java
           java(
             """
-                  import org.apache.logging.log4j.Logger;
-                  import org.apache.logging.log4j.LogManager;
-                  
-                  public class SingleStatementIf {
-                    Logger log = LogManager.getLogger();
-                  
-                    public void foo() {
-                      if (log.isDebugEnabled())
-                        log.debug("first" + "second");
-                    }
-                  
-                    private String bar() {
-                      return null;
-                    }
-                  }
-                """,
+              import org.apache.logging.log4j.Logger;
+              import org.apache.logging.log4j.LogManager;
+              
+              public class SingleStatementIf {
+                Logger log = LogManager.getLogger();
+              
+                public void foo() {
+                  if (log.isDebugEnabled())
+                    log.debug("first" + "second");
+                }
+              
+                private String bar() {
+                  return null;
+                }
+              }
+              """,
             """
-                  import org.slf4j.Logger;
-                  import org.slf4j.LoggerFactory;
-                  
-                  public class SingleStatementIf {
-                    Logger log = LoggerFactory.getLogger();
-                  
-                    public void foo() {
-                      if (log.isDebugEnabled())
-                        log.debug("first" + "second");
-                    }
-                  
-                    private String bar() {
-                      return null;
-                    }
-                  }
-               """
+              import org.slf4j.Logger;
+              import org.slf4j.LoggerFactory;
+              
+              public class SingleStatementIf {
+                Logger log = LoggerFactory.getLogger();
+              
+                public void foo() {
+                  if (log.isDebugEnabled())
+                    log.debug("first" + "second");
+                }
+              
+                private String bar() {
+                  return null;
+                }
+              }
+              """
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/logging/slf4j/Log4j2ToSlf4j1Test.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/Log4j2ToSlf4j1Test.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.logging.slf4j;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.config.Environment;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -132,6 +133,53 @@ class Log4j2ToSlf4j1Test implements RewriteTest {
                   }
               }
               """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/185")
+    void singleStatementIf() {
+        rewriteRun(
+          spec -> spec.recipe(Environment.builder()
+            .scanRuntimeClasspath("org.openrewrite.java.logging")
+            .build()
+            .activateRecipes("org.openrewrite.java.logging.slf4j.Log4j2ToSlf4j1")),
+          java(
+            """
+                  import org.apache.logging.log4j.Logger;
+                  import org.apache.logging.log4j.LogManager;
+                  
+                  public class SingleStatementIf {
+                    Logger log = LogManager.getLogger();
+                  
+                    public void foo() {
+                      if (log.isDebugEnabled())
+                        log.debug("first" + "second");
+                    }
+                  
+                    private String bar() {
+                      return null;
+                    }
+                  }
+                """,
+            """
+                  import org.slf4j.Logger;
+                  import org.slf4j.LoggerFactory;
+                  
+                  public class SingleStatementIf {
+                    Logger log = LoggerFactory.getLogger();
+                  
+                    public void foo() {
+                      if (log.isDebugEnabled())
+                        log.debug("first" + "second");
+                    }
+                  
+                    private String bar() {
+                      return null;
+                    }
+                  }
+               """
           )
         );
     }


### PR DESCRIPTION
## What's changed?
- Add test case for https://github.com/openrewrite/rewrite-logging-frameworks/issues/185
- [ ] TODO: fix issue

## What's your motivation?
- https://github.com/openrewrite/rewrite-logging-frameworks/issues/185

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
Is this in the right test class? Should there be a separate Log4jToSlf4Test class?

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files