### PR TITLE
Do not fail ParameterizedLogging for Kotlin String templates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params:latest.release")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:latest.release")
 
+    testImplementation("org.openrewrite:rewrite-kotlin:${rewriteVersion}")
     testImplementation("org.openrewrite:rewrite-maven")
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite:rewrite-java-tck")

--- a/src/main/java/org/openrewrite/java/logging/ParameterizedLogging.java
+++ b/src/main/java/org/openrewrite/java/logging/ParameterizedLogging.java
@@ -108,9 +108,7 @@ public class ParameterizedLogging extends Recipe {
                                 .apply(new Cursor(getCursor().getParent(), m), m.getCoordinates().replaceArguments(), newArgList.toArray());
                     } else if (logMsg instanceof J.Identifier && TypeUtils.isAssignableTo("java.lang.Throwable", logMsg.getType())) {
                         return m;
-                    } else if (!TypeUtils.isString(logMsg.getType()) &&
-                               logMsg.getType() instanceof JavaType.Class &&
-                               !((JavaType.Class) logMsg.getType()).getFullyQualifiedName().startsWith("kotlin")) {
+                    } else if (!TypeUtils.isString(logMsg.getType()) && logMsg.getType() instanceof JavaType.Class) {
                         StringBuilder messageBuilder = new StringBuilder("\"{}\"");
                         m.getArguments().forEach(arg -> messageBuilder.append(", #{any()}"));
                         m = JavaTemplate.builder(escapeDollarSign(messageBuilder.toString()))

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -20,10 +20,12 @@ import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.kotlin.Assertions.kotlin;
 
 @SuppressWarnings({
   "EmptyTryBlock",
@@ -613,16 +615,36 @@ class ParameterizedLoggingTest implements RewriteTest {
               }
               """,
             """
-               import org.slf4j.Logger;
-               import org.slf4j.Marker;
+              import org.slf4j.Logger;
+              import org.slf4j.Marker;
 
-               class Test {
-                   static void method(Logger logger, Marker marker, String name) {
-                       logger.info(marker, "Hello {}, nice to meet you {}", name, name);
-                   }
-               }
-               """
+              class Test {
+                  static void method(Logger logger, Marker marker, String name) {
+                      logger.info(marker, "Hello {}, nice to meet you {}", name, name);
+                  }
+              }
+              """
           )
         );
     }
+
+    @Test
+    void kotlinStringTemplate() {
+        rewriteRun(
+          spec -> spec
+            .recipe(new ParameterizedLogging("org.slf4j.Logger info(..)", false))
+            .parser(KotlinParser.builder().classpathFromResources(new InMemoryExecutionContext(), "slf4j-api-2.1")),
+          //language=kotlin
+          kotlin(
+            """
+              import org.slf4j.Logger
+
+              fun main(logger: Logger, name: String) {
+                  logger.info("Hello $name")
+              }
+              """
+          )
+        );
+    }
+
 }

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -629,7 +629,7 @@ class ParameterizedLoggingTest implements RewriteTest {
     }
 
     @Test
-    void kotlinStringTemplate() {
+    void kotlinStringTemplateSkipped() {
         rewriteRun(
           spec -> spec
             .recipe(new ParameterizedLogging("org.slf4j.Logger info(..)", false))
@@ -641,10 +641,10 @@ class ParameterizedLoggingTest implements RewriteTest {
 
               fun main(logger: Logger, name: String) {
                   logger.info("Hello $name")
+                  logger.info("Hello " + name)
               }
               """
           )
         );
     }
-
 }


### PR DESCRIPTION
As [reported via Slack](https://rewriteoss.slack.com/archives/C01A843MWG5/p1732921289938769).