### PR TITLE
Drop `contextSensitive()` from `JavaTemplate` to fix compilation

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/LoggingFramework.java
+++ b/src/main/java/org/openrewrite/java/logging/LoggingFramework.java
@@ -53,37 +53,28 @@ public enum LoggingFramework {
             case SLF4J:
                 return JavaTemplate
                         .builder("#{any(org.slf4j.Logger)}.error(" + message + ", #{any(java.lang.Throwable)})")
-                        .contextSensitive()
-                        .javaParser(JavaParser.fromJavaVersion()
-                                .classpathFromResources(ctx, "slf4j-api-2.1"))
+                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "slf4j-api-2.1"))
                         .build();
             case Log4J1:
                 return JavaTemplate
                         .builder("#{any(org.apache.log4j.Category)}.error(" + message + ", #{any(java.lang.Throwable)})")
-                        .contextSensitive()
-                        .javaParser(JavaParser.fromJavaVersion()
-                                .classpathFromResources(ctx, "log4j-1.2"))
+                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "log4j-1.2"))
                         .build();
 
             case Log4J2:
                 return JavaTemplate
                         .builder("#{any(org.apache.logging.log4j.Logger)}.error(" + message + ", #{any(java.lang.Throwable)})")
-                        .contextSensitive()
-                        .javaParser(JavaParser.fromJavaVersion()
-                                .classpathFromResources(ctx, "log4j-api-2.23"))
+                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "log4j-api-2.23"))
                         .build();
             case COMMONS:
                 return JavaTemplate
                         .builder("#{any(org.apache.commons.logging.Log)}.error(" + message + ", #{any(java.lang.Throwable)})")
-                        .contextSensitive()
-                        .javaParser(JavaParser.fromJavaVersion()
-                                .classpathFromResources(ctx, "commons-logging-1.3"))
+                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "commons-logging-1.3"))
                         .build();
             case JUL:
             default:
                 return JavaTemplate
                         .builder("#{any(java.util.logging.Logger)}.log(Level.SEVERE, " + message + ", #{any(java.lang.Throwable)})")
-                        .contextSensitive()
                         .imports("java.util.logging.Level")
                         .build();
         }

--- a/src/main/java/org/openrewrite/java/logging/SystemErrToLogging.java
+++ b/src/main/java/org/openrewrite/java/logging/SystemErrToLogging.java
@@ -193,31 +193,24 @@ public class SystemErrToLogging extends Recipe {
                 switch (framework) {
                     case SLF4J:
                         return JavaTemplate
-                                .builder("#{any(org.slf4j.Logger)}.error(#{any(String)})")
-                                .contextSensitive()
-                                .javaParser(JavaParser.fromJavaVersion()
-                                        .classpathFromResources(ctx, "slf4j-api-2.1"))
+                                .builder("#{any(org.slf4j.Logger)}.error(#{any(String)});")
+                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "slf4j-api-2.1"))
                                 .build();
                     case Log4J1:
                         return JavaTemplate
-                                .builder("#{any(org.apache.log4j.Category)}.error(#{any(String)})")
-                                .contextSensitive()
-                                .javaParser(JavaParser.fromJavaVersion()
-                                        .classpathFromResources(ctx, "log4j-1.2"))
+                                .builder("#{any(org.apache.log4j.Category)}.error(#{any(String)});")
+                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "log4j-1.2"))
                                 .build();
 
                     case Log4J2:
                         return JavaTemplate
-                                .builder("#{any(org.apache.logging.log4j.Logger)}.error(#{any(String)})")
-                                .contextSensitive()
-                                .javaParser(JavaParser.fromJavaVersion()
-                                        .classpathFromResources(ctx, "log4j-api-2.23"))
+                                .builder("#{any(org.apache.logging.log4j.Logger)}.error(#{any(String)});")
+                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "log4j-api-2.23"))
                                 .build();
                     case JUL:
                     default:
                         return JavaTemplate
-                                .builder("#{any(java.util.logging.Logger)}.log(Level.SEVERE, #{any(String)})")
-                                .contextSensitive()
+                                .builder("#{any(java.util.logging.Logger)}.log(Level.SEVERE, #{any(String)});")
                                 .imports("java.util.logging.Level")
                                 .build();
                 }


### PR DESCRIPTION
Looks like these weren't necessary anymore, but the compilation errors they had only showed after
- https://github.com/openrewrite/rewrite/pull/4412