### PR TITLE
Remove log4j from runtime classpath as it is only needed to generate a recipe from a refaster template

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,10 @@ recipeDependencies {
 }
 
 dependencies {
+    compileOnly("log4j:log4j:1.+") {
+        because("log4j 1 has critical vulnerabilities but we need the type for the refaster recipe during compilation")
+    }
+
     compileOnly("org.projectlombok:lombok:latest.release")
     annotationProcessor("org.projectlombok:lombok:latest.release")
 
@@ -31,7 +35,6 @@ dependencies {
     implementation("org.openrewrite.recipe:rewrite-static-analysis:${rewriteVersion}")
     runtimeOnly("org.openrewrite:rewrite-java-17")
 
-    implementation("log4j:log4j:1.+")
     implementation("org.apache.logging.log4j:log4j-core:2.+")
     implementation("org.slf4j:slf4j-api:2.+")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,3 +55,4 @@ dependencies {
     testImplementation("org.openrewrite:rewrite-java-tck")
 
     testImplementation("org.assertj:assertj-core:latest.release")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,10 +20,6 @@ recipeDependencies {
 }
 
 dependencies {
-    compileOnly("log4j:log4j:1.+") {
-        because("log4j 1 has critical vulnerabilities but we need the type for the refaster recipe during compilation")
-    }
-
     compileOnly("org.projectlombok:lombok:latest.release")
     annotationProcessor("org.projectlombok:lombok:latest.release")
 
@@ -44,6 +40,11 @@ dependencies {
         exclude("com.google.auto.service", "auto-service-annotations")
     }
 
+    compileOnly("log4j:log4j:1.+") {
+        because("log4j 1 has critical vulnerabilities but we need the type for the refaster recipe during compilation")
+    }
+    testRuntimeOnly("log4j:log4j:1.+") // Necessary to match for now; explore alternatives for Refaster classpath in the future
+
     testImplementation("org.junit.jupiter:junit-jupiter-api:latest.release")
     testImplementation("org.junit.jupiter:junit-jupiter-params:latest.release")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:latest.release")
@@ -54,4 +55,3 @@ dependencies {
     testImplementation("org.openrewrite:rewrite-java-tck")
 
     testImplementation("org.assertj:assertj-core:latest.release")
-}

--- a/src/test/java/org/openrewrite/java/logging/log4j/Log4j1ToLog4j2Test.java
+++ b/src/test/java/org/openrewrite/java/logging/log4j/Log4j1ToLog4j2Test.java
@@ -17,7 +17,6 @@ package org.openrewrite.java.logging.log4j;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
-import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
@@ -35,8 +34,7 @@ class Log4j1ToLog4j2Test implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResource("/META-INF/rewrite/log4j.yml", "org.openrewrite.java.logging.log4j.Log4j1ToLog4j2")
-          .parser(JavaParser.fromJavaVersion()
-            .classpathFromResources(new InMemoryExecutionContext(), "log4j-1.2"));
+          .parser(JavaParser.fromJavaVersion().classpath("log4j"));
     }
 
     @DocumentExample


### PR DESCRIPTION
This does not yet work as expected in the test

## What's changed?
Moved dependency to `compileOnly`

## What's your motivation?
Vulnerability

## Anything in particular you'd like reviewers to focus on?
why does the test not work? logback 1 should be on the classpath because `classpathFromResources` but it is not available:

<img width="1467" alt="Screenshot 2024-12-20 at 10 20 26" src="https://github.com/user-attachments/assets/8e0271b8-df7b-4939-850f-2747563bbf42" />


## Anyone you would like to review specifically?
@timtebeek @knutwannheden 
