### PR TITLE
`ParameterizedLogging` support for logger fields added through Lombok annotations

### DIFF
--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -721,7 +721,7 @@ class ParameterizedLoggingTest implements RewriteTest {
               @Slf4j
               class Test {
                   static void method(String name) {
-                      log.info(marker, "Hello " + name + ", nice to meet you " + name);
+                      log.info"Hello " + name + ", nice to meet you " + name);
                   }
               }
               """,
@@ -731,7 +731,7 @@ class ParameterizedLoggingTest implements RewriteTest {
               @Slf4j
               class Test {
                   static void method(String name) {
-                      log.info(marker, "Hello {}, nice to meet you {}", name, name);
+                      log.info("Hello {}, nice to meet you {}", name, name);
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -37,7 +37,7 @@ class ParameterizedLoggingTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion()
-          .classpathFromResources(new InMemoryExecutionContext(), "slf4j-api-2.1", "log4j-api-2.23", "log4j-core-2.23"));
+          .classpathFromResources(new InMemoryExecutionContext(), "slf4j-api-2.1", "log4j-api-2.23", "log4j-core-2.23", "lombok-1.18"));
     }
 
     @DocumentExample
@@ -697,4 +697,33 @@ class ParameterizedLoggingTest implements RewriteTest {
         );
     }
 
+    @Test
+    void lombokLoggingAnnotation() {
+        rewriteRun(
+          spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger info(..)", false)),
+          // language=java
+          java(
+            """
+              import lombok.extern.slf4j.Slf4j;
+
+              @Slf4j
+              class Test {
+                  static void method(String name) {
+                      log.info(marker, "Hello " + name + ", nice to meet you " + name);
+                  }
+              }
+              """,
+            """
+              import lombok.extern.slf4j.Slf4j;
+
+              @Slf4j
+              class Test {
+                  static void method(String name) {
+                      log.info(marker, "Hello {}, nice to meet you {}", name, name);
+                  }
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.logging;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
@@ -35,16 +36,6 @@ import static org.openrewrite.kotlin.Assertions.kotlin;
   "PlaceholderCountMatchesArgumentCount"
 })
 class ParameterizedLoggingTest implements RewriteTest {
-
-    @BeforeAll
-    static void setUp() {
-        System.setProperty("rewrite.lombok", "true");
-    }
-
-    @AfterAll
-    static void tearDown() {
-        System.clearProperty("rewrite.lombok");
-    }
 
     @Override
     public void defaults(RecipeSpec spec) {
@@ -709,33 +700,48 @@ class ParameterizedLoggingTest implements RewriteTest {
         );
     }
 
-    @Test
-    void lombokLoggingAnnotation() {
-        rewriteRun(
-          spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger info(..)", false)),
-          // language=java
-          java(
-            """
-              import lombok.extern.slf4j.Slf4j;
+    @Nested
+    class LombokSupport {
 
-              @Slf4j
-              class Test {
-                  static void method(String name) {
-                      log.info"Hello " + name + ", nice to meet you " + name);
-                  }
-              }
-              """,
-            """
-              import lombok.extern.slf4j.Slf4j;
+        @BeforeAll
+        static void setUp() {
+            System.setProperty("rewrite.lombok", "true");
+        }
 
-              @Slf4j
-              class Test {
-                  static void method(String name) {
-                      log.info("Hello {}, nice to meet you {}", name, name);
+        @AfterAll
+        static void tearDown() {
+            System.clearProperty("rewrite.lombok");
+        }
+
+        @Test
+        void lombokLoggingAnnotation() {
+            rewriteRun(
+              spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger info(..)", false)),
+              // language=java
+              java(
+                """
+                  import lombok.extern.slf4j.Slf4j;
+
+                  @Slf4j
+                  class Test {
+                      static void method(String name) {
+                          log.info("Hello " + name + ", nice to meet you " + name);
+                      }
                   }
-              }
-              """
-          )
-        );
+                  """,
+                """
+                  import lombok.extern.slf4j.Slf4j;
+
+                  @Slf4j
+                  class Test {
+                      static void method(String name) {
+                          log.info("Hello {}, nice to meet you {}", name, name);
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
     }
 }

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.java.logging;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
@@ -34,10 +36,20 @@ import static org.openrewrite.kotlin.Assertions.kotlin;
 })
 class ParameterizedLoggingTest implements RewriteTest {
 
+    @BeforeAll
+    static void setUp() {
+        System.setProperty("rewrite.lombok", "true");
+    }
+
+    @AfterAll
+    static void tearDown() {
+        System.clearProperty("rewrite.lombok");
+    }
+
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion()
-          .classpathFromResources(new InMemoryExecutionContext(), "slf4j-api-2.1", "log4j-api-2.23", "log4j-core-2.23", "lombok-1.18"));
+          .classpathFromResources(new InMemoryExecutionContext(), "slf4j-api-2.1", "log4j-api-2.23", "log4j-core-2.23", "lombok"));
     }
 
     @DocumentExample


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
**Only tests**

Openrewrite can [convert](https://docs.openrewrite.org/recipes/java/logging/parameterizedlogging) log statements into parameterized log statements, often yielding substantial performance gain. However, currently, loggers that are generated through a Lombok annotation, e.g., `@Slf4j`, are not supported.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
- https://projectlombok.org/api/lombok/extern/slf4j/Slf4j
- https://docs.openrewrite.org/recipes/java/logging/parameterizedlogging

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
