### PR TITLE
refactor: Use a standard name for `ExecutionContext`

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/CatchBlockLogLevel.java
+++ b/src/main/java/org/openrewrite/java/logging/CatchBlockLogLevel.java
@@ -91,8 +91,8 @@ public class CatchBlockLogLevel extends Recipe {
                 AtomicBoolean found = new AtomicBoolean(false);
                 new JavaIsoVisitor<ExecutionContext>() {
                     @Override
-                    public J.Identifier visitIdentifier(J.Identifier identifier, ExecutionContext executionContext) {
-                        J.Identifier i = super.visitIdentifier(identifier, executionContext);
+                    public J.Identifier visitIdentifier(J.Identifier identifier, ExecutionContext ctx) {
+                        J.Identifier i = super.visitIdentifier(identifier, ctx);
                         found.set(found.get() || TypeUtils.isAssignableTo("java.lang.Throwable", i.getType()));
                         return i;
                     }

--- a/src/main/java/org/openrewrite/java/logging/logback/ConfigureLoggerLevel.java
+++ b/src/main/java/org/openrewrite/java/logging/logback/ConfigureLoggerLevel.java
@@ -81,8 +81,8 @@ public class ConfigureLoggerLevel extends Recipe {
             final XPathMatcher loggerMatcher = new XPathMatcher("/configuration/logger[@name='" + className + "']");
 
             @Override
-            public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext executionContext) {
-                Xml.Tag t = super.visitTag(tag, executionContext);
+            public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                Xml.Tag t = super.visitTag(tag, ctx);
                 if (loggerMatcher.matches(getCursor())) {
                     getCursor().putMessageOnFirstEnclosing(Xml.Document.class, "found", true);
                     t = t.withAttributes(ListUtils.map(t.getAttributes(), a -> {


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.java.recipes.ExecutionContextParameterName?organizationId=T3BlblJld3JpdGU%3D