### PR TITLE
Allow parameterized logger in returned anonymous class implementation

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/ParameterizedLogging.java
+++ b/src/main/java/org/openrewrite/java/logging/ParameterizedLogging.java
@@ -105,7 +105,6 @@ public class ParameterizedLogging extends Recipe {
                             return message;
                         });
                         m = JavaTemplate.builder(escapeDollarSign(messageBuilder.toString()))
-                                .contextSensitive()
                                 .build()
                                 .apply(new Cursor(getCursor().getParent(), m), m.getCoordinates().replaceArguments(), newArgList.toArray());
                     } else if (logMsg instanceof J.Identifier && TypeUtils.isAssignableTo("java.lang.Throwable", logMsg.getType())) {


### PR DESCRIPTION
## What's changed?

Removed the method call `contextSensitive()` on `JavaTemplate` though that may not be the "right" fix. Please advise.

## What's your motivation?

Under certain conditions, the following exception is thrown.

```
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
java.base/java.util.Objects.checkIndex(Objects.java:361)
java.base/java.util.ArrayList.get(ArrayList.java:427)
org.openrewrite.java.internal.template.JavaTemplateParser.parseMethodArguments(JavaTemplateParser.java:210)
org.openrewrite.java.internal.template.JavaTemplateJavaExtension$1.visitMethodInvocation(JavaTemplateJavaExtension.java:390)
org.openrewrite.java.internal.template.JavaTemplateJavaExtension$1.visitMethodInvocation(JavaTemplateJavaExtension.java:55)
org.openrewrite.java.tree.J$MethodInvocation.acceptJava(J.java:4079)
org.openrewrite.java.tree.J.accept(J.java:58)
org.openrewrite.TreeVisitor.visit(TreeVisitor.java:241)
org.openrewrite.TreeVisitor.visit(TreeVisitor.java:153)
org.openrewrite.java.JavaTemplate.apply(JavaTemplate.java:115)
org.openrewrite.java.logging.ParameterizedLogging$1.visitMethodInvocation(ParameterizedLogging.java:110)
org.openrewrite.java.logging.ParameterizedLogging$1.visitMethodInvocation(ParameterizedLogging.java:77)
org.openrewrite.java.tree.J$MethodInvocation.acceptJava(J.java:4079)
```

I could only produce one use case that exposed the behavior, represented in the test method `returnsAnonymousClassThatUsesLoggerInMethodImplementation`. The following two test methods have been added for completeness sake.

## Anything in particular you'd like reviewers to focus on?

The particular fix.