### PR TITLE
Add `InexpensiveSLF4JLoggers` to `Slf4jBestPractices`

### DIFF
--- a/src/main/resources/META-INF/rewrite/slf4j.yml
+++ b/src/main/resources/META-INF/rewrite/slf4j.yml
@@ -143,6 +143,7 @@ recipeList:
   - org.openrewrite.java.logging.slf4j.Slf4jLogShouldBeConstant
   - org.openrewrite.java.logging.slf4j.CompleteExceptionLogging
   - org.openrewrite.java.logging.CatchBlockLogLevel
+  - org.openrewrite.java.logging.slf4j.InexpensiveSLF4JLoggers
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.java.logging.slf4j.CommonsLogging1ToSlf4j1


### PR DESCRIPTION
## What's your motivation?
Not having to run this recipe individually, or having to remember to add it to a composite

## Anyone you would like to review specifically?
This now fails `org.openrewrite.java.logging.slf4j.Slf4jBestPracticesTest#exceptionIsAppendedAtEndOfLogMessage`; I wonder if we should even add these conditional blocks for log levels warn & error, as they are hardly ever disabled. Maybe make it optionally configurable and only add blocks up to `info` by default?
```diff
diff --git a/Test.java b/Test.java
index 2ee8c4f..fab82d5 100644
--- a/Test.java
+++ b/Test.java
@@ -6,9 +6,11 @@ 
         try {
           throw new IllegalStateException("oops");
         } catch (Exception e) {
-          logger.error("aaa: {}", e);
-          logger.error("bbb: {}", String.valueOf(e));
-          logger.error("ccc: {}", e.toString());
+            if (logger.isErrorEnabled()) {
+                logger.error("aaa: {}", e);
+                logger.error("bbb: {}", String.valueOf(e));
+                logger.error("ccc: {}", e.toString());
+            }
         }
     }
 }
\ No newline at end of file
```

## Any additional context
- Follow up from https://github.com/openrewrite/rewrite-logging-frameworks/pull/215