### PR TITLE
Make inexpensive log statements less noisy

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
@@ -87,7 +87,6 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
                                 .withThenPart(m.withPrefix(m.getPrefix().withWhitespace("\n" + m.getPrefix().getWhitespace().replace("\n", ""))))
                                 .withPrefix(m.getPrefix().withComments(emptyList()));
                         visitedBlocks.add(id);
-                        //return autoFormat(if_, ctx);
                         return if_;
                     }
                 }
@@ -130,7 +129,6 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
                 for (Statement statement : b.getStatements()) {
                     acc.push(statement);
                 }
-                //return autoFormat(b.withStatements(acc.pull()), ctx);
                 return b.withStatements(acc.pull());
             }
             return b;

--- a/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
@@ -87,7 +87,8 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
                                 .withThenPart(m.withPrefix(m.getPrefix().withWhitespace("\n" + m.getPrefix().getWhitespace().replace("\n", ""))))
                                 .withPrefix(m.getPrefix().withComments(emptyList()));
                         visitedBlocks.add(id);
-                        return autoFormat(if_, ctx);
+                        //return autoFormat(if_, ctx);
+                        return if_;
                     }
                 }
             }
@@ -125,11 +126,12 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
         public J.Block visitBlock(J.Block block, ExecutionContext ctx) {
             J.Block b = super.visitBlock(block, ctx);
             if (blockIds.contains(b.getId())) {
-                StatementAccumulator acc = new StatementAccumulator();
+                StatementAccumulator acc = new StatementAccumulator(this, ctx);
                 for (Statement statement : b.getStatements()) {
                     acc.push(statement);
                 }
-                return autoFormat(b.withStatements(acc.pull()), ctx);
+                //return autoFormat(b.withStatements(acc.pull()), ctx);
+                return b.withStatements(acc.pull());
             }
             return b;
         }
@@ -149,10 +151,17 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
      */
     private static class StatementAccumulator {
 
+        private final JavaIsoVisitor<ExecutionContext> visitor;
+        private final ExecutionContext ctx;
         AccumulatorKind accumulatorKind = AccumulatorKind.NONE;
         List<Statement> statements = new ArrayList<>();
         List<Statement> logStatementsCache = new ArrayList<>();
         J.@Nullable If ifCache = null;
+
+        public StatementAccumulator(JavaIsoVisitor<ExecutionContext> visitor, ExecutionContext ctx) {
+            this.visitor = visitor;
+            this.ctx = ctx;
+        }
 
         public void push(Statement statement) {
             AccumulatorKind newKind = getKind(statement);
@@ -228,7 +237,7 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
             if (ifCache == null) {
                 statements.addAll(logStatementsCache);
             } else {
-                statements.add(ifCache.withThenPart(new J.Block(randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), logStatementsCache.stream().map(JRightPadded::build).collect(Collectors.toList()), Space.EMPTY)));
+                statements.add((Statement) visitor.autoFormat(ifCache.withThenPart(new J.Block(randomId(), Space.EMPTY, Markers.EMPTY, JRightPadded.build(false), logStatementsCache.stream().map(JRightPadded::build).collect(Collectors.toList()), Space.EMPTY)), ctx, visitor.getCursor()));
             }
             logStatementsCache.clear();
             ifCache = null;

--- a/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
@@ -151,10 +151,10 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
     private static class StatementAccumulator {
 
         private final Function<J, J> formatter;
-        AccumulatorKind accumulatorKind = AccumulatorKind.NONE;
-        List<Statement> statements = new ArrayList<>();
-        List<Statement> logStatementsCache = new ArrayList<>();
-        J.@Nullable If ifCache = null;
+        private final List<Statement> statements = new ArrayList<>();
+        private final List<Statement> logStatementsCache = new ArrayList<>();
+        private AccumulatorKind accumulatorKind = AccumulatorKind.NONE;
+        private J.@Nullable If ifCache = null;
 
         public StatementAccumulator(Function<J, J> formatter) {
             this.formatter = formatter;

--- a/src/test/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionalsTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionalsTest.java
@@ -478,7 +478,7 @@ class WrapExpensiveLogStatementsInConditionalsTest implements RewriteTest {
                       LOG.info("Do something different {}", expensiveOp());
 
                       System.out.println();
-                   }
+                  }
 
                   String expensiveOp() {
                       return "expensive";
@@ -503,6 +503,73 @@ class WrapExpensiveLogStatementsInConditionalsTest implements RewriteTest {
                       }
 
                       System.out.println();
+                  }
+
+                  String expensiveOp() {
+                      return "expensive";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void leaveSurroundingFormatting() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.slf4j.Logger;
+              import java.lang.StringBuilder;
+
+              class A {
+                  String method(Logger LOG, StringBuilder builder) {
+                          System.out.println();
+
+                      // Log this as Info
+                      LOG.info("Do something {}", expensiveOp());
+
+                      // Log this also
+                      LOG.info("Do something else {}", expensiveOp());
+                      // And this
+                      LOG.info("Do something different {}", expensiveOp());
+
+                      return builder
+                                                  .append("test")
+                                          .append(1)
+                                 .append(true)
+                                 .toString();
+                  }
+
+                  String expensiveOp() {
+                      return "expensive";
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+              import java.lang.StringBuilder;
+
+              class A {
+                  String method(Logger LOG, StringBuilder builder) {
+                          System.out.println();
+
+                      if (LOG.isInfoEnabled()) {
+                          // Log this as Info
+                          LOG.info("Do something {}", expensiveOp());
+
+                          // Log this also
+                          LOG.info("Do something else {}", expensiveOp());
+                          // And this
+                          LOG.info("Do something different {}", expensiveOp());
+                      }
+
+                      return builder
+                                                  .append("test")
+                                          .append(1)
+                                 .append(true)
+                                 .toString();
                   }
 
                   String expensiveOp() {


### PR DESCRIPTION
## What's changed?
Scoped autoformat better, so the recipe does not reformat lines it does not touch.
