### PR TITLE
Exclude spotbugs dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,9 @@ dependencies {
     implementation("org.openrewrite.recipe:rewrite-static-analysis:${rewriteVersion}")
     runtimeOnly("org.openrewrite:rewrite-java-17")
 
-    implementation("org.apache.logging.log4j:log4j-core:2.+")
+    implementation("org.apache.logging.log4j:log4j-core:2.+") {
+        exclude("com.github.spotbugs", "spotbugs-annotations").because("https://github.com/apache/logging-log4j2/issues/3754")
+    }
     implementation("org.slf4j:slf4j-api:2.+")
 
     annotationProcessor("org.openrewrite:rewrite-templating:$rewriteVersion")


### PR DESCRIPTION
## What's changed?

Excluding the Spotbugs dependency

## What's your motivation?

Fix the broken CI:
```
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not resolve com.github.spotbugs:spotbugs-annotations:4.9.3.
     Required by:
         root project : > org.apache.logging.log4j:log4j-core:2.25.0
         root project : > org.apache.logging.log4j:log4j-core:2.25.0 > org.apache.logging.log4j:log4j-api:2.25.0
      > Dependency resolution is looking for a library compatible with JVM runtime version 8, but 'com.github.spotbugs:spotbugs-annotations:4.9.3' is only compatible with JVM runtime version 11 or newer.
```
Related to: https://github.com/apache/logging-log4j2/issues/3754

Also I don't think we need this Spotbugs at all. Not sure why they export it.