### PR TITLE
fix: match `.toString()` on any type, not just java.lang.Object

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/ParameterizedLogging.java
+++ b/src/main/java/org/openrewrite/java/logging/ParameterizedLogging.java
@@ -146,7 +146,7 @@ public class ParameterizedLogging extends Recipe {
 
     private static class RemoveToStringVisitor extends JavaVisitor<ExecutionContext> {
         private final JavaTemplate t = JavaTemplate.builder("#{any(java.lang.String)}").build();
-        private final MethodMatcher TO_STRING = new MethodMatcher("java.lang.Object toString()");
+        private final MethodMatcher TO_STRING = new MethodMatcher("*..* toString()");
 
         @Override
         public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -98,6 +98,37 @@ class ParameterizedLoggingTest implements RewriteTest {
         );
     }
 
+    @SuppressWarnings("UnnecessaryToStringCall")
+    @Test
+    void noNeedToCallToStringOnParameterizedArgumentOfAnyType() {
+        rewriteRun(
+          spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger info(..)", true)),
+          //language=java
+          java(
+            """
+              import java.util.stream.Stream;
+              import org.slf4j.Logger;
+
+              class Test {
+                  static void method(Logger logger, Stream person) {
+                      logger.info("Hello " + person.toString() + ", your name has " + person.toString().length() + " characters. Just counting " + person.toString());
+                  }
+              }
+              """,
+            """
+              import java.util.stream.Stream;
+              import org.slf4j.Logger;
+
+              class Test {
+                  static void method(Logger logger, Stream person) {
+                      logger.info("Hello {}, your name has {} characters. Just counting {}", person, person.toString().length(), person);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void doNotRemoveStringOnParameterizedArgument() {
         rewriteRun(


### PR DESCRIPTION
`MethodMatcher()` pattern doesn't match subtypes of the specified receiver

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
The `Parameterize logging statements` recipe has an optional feature to remove `.toString()` from the arguments that are to be parameterized. There is a bug where only the `java.lang.Object` parameters would get `.toString()` stripped, the method matcher for `toString()` is too narrow.

## Any additional context
https://docs.openrewrite.org/reference/method-patterns#examples

Added a new test and validated on the apache repos, specifically for example [here](https://github.com/apache/opennlp/blob/3ec9e1592cf58da65a4744247e44bdb5c5d9ab70/opennlp-tools/src/main/java/opennlp/tools/parser/Parse.java#L1039-L1041)

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
