### PR TITLE
fix: any last argument matching `Throwable.toString()` is left as is

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/slf4j/StripToStringFromArguments.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/StripToStringFromArguments.java
@@ -78,7 +78,7 @@ public class StripToStringFromArguments extends Recipe {
                                 J.MethodInvocation toStringInvocation = (J.MethodInvocation) arg;
                                 if (TO_STRING_MATCHER.matches(toStringInvocation.getMethodType()) &&
                                     toStringInvocation.getSelect() != null &&
-                                    !(firstFormatArgIndex == lastArgIndex && TypeUtils.isAssignableTo("java.lang.Throwable", toStringInvocation.getSelect().getType()))) {
+                                    !(index == lastArgIndex && TypeUtils.isAssignableTo("java.lang.Throwable", toStringInvocation.getSelect().getType()))) {
                                     // Strip the `.toString()` call
                                     return toStringInvocation.getSelect().withPrefix(toStringInvocation.getPrefix());
                                 }

--- a/src/test/java/org/openrewrite/java/logging/slf4j/StripToStringFromArgumentsTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/StripToStringFromArgumentsTest.java
@@ -57,7 +57,7 @@ class StripToStringFromArgumentsTest implements RewriteTest {
                         ", exception, o1"),
                 new TestCase(
                         ", o1, exception.toString()",
-                        ", o1, exception")
+                        ", o1, exception.toString()")
         );
 
         return Stream.of("trace", "debug", "info", "warn", "error")


### PR DESCRIPTION
Fixes https://github.com/openrewrite/rewrite-logging-frameworks/issues/228

In SLF4J, the last argument of the logging methods will be treated specially and removed from the formatted string argument array if it's a Throwable.

When the last argument was a `.toString()` call we stripped it even if it was a `Throwable` which changed the behaviour.

https://www.slf4j.org/faq.html#paramException