### PR TITLE
Don't if-wrap logs when arguments are getters

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
@@ -163,8 +163,7 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
             if (expression instanceof J.MethodInvocation) {
                 J.MethodInvocation mi = (J.MethodInvocation) expression;
                 if (isSimpleGetter(mi) && mi.getMethodType() != null) {
-                    JavaType returnType = mi.getMethodType().getReturnType();
-                    if (returnType == JavaType.Primitive.Boolean || (returnType instanceof JavaType.FullyQualified && "java.lang.Boolean".equals(((JavaType.FullyQualified) returnType).getFullyQualifiedName()))) {
+                    if (isTypeBoolean(mi.getMethodType().getReturnType())) {
                         return true;
                     }
                 }
@@ -172,12 +171,12 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
             return false;
         }
         private static boolean isBooleanIdentifier(J expression) {
-            if (expression instanceof J.Identifier) {
-                J.Identifier identifier = (J.Identifier) expression;
-                JavaType type = identifier.getType();
-                return type != null && (type == JavaType.Primitive.Boolean || (type instanceof JavaType.FullyQualified && "java.lang.Boolean".equals(((JavaType.FullyQualified) type).getFullyQualifiedName())));
-            }
-            return false;
+            return expression instanceof J.Identifier && isTypeBoolean(((J.Identifier) expression).getType());
+        }
+
+        private static boolean isTypeBoolean(JavaType type) {
+            return type == JavaType.Primitive.Boolean ||
+                   (type instanceof JavaType.FullyQualified && "java.lang.Boolean".equals(((JavaType.FullyQualified) type).getFullyQualifiedName()));
         }
 
     }

--- a/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
@@ -74,10 +74,10 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
         public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
             if (
-                    m.getSelect() != null
-                    && (infoMatcher.matches(m) || debugMatcher.matches(m) || traceMatcher.matches(m))
-                    && !isInIfStatementWithLogLevelCheck(getCursor(), m)
-                    && isAnyArgumentExpensive(m)
+                    m.getSelect() != null &&
+                    (infoMatcher.matches(m) || debugMatcher.matches(m) || traceMatcher.matches(m)) &&
+                    !isInIfStatementWithLogLevelCheck(getCursor(), m) &&
+                    isAnyArgumentExpensive(m)
             ) {
                 J container = getCursor().getParentTreeCursor().getValue();
                 if (container instanceof J.Block) {

--- a/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
@@ -128,6 +128,7 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
                                     (arg instanceof J.MethodInvocation && isSimpleGetter((J.MethodInvocation) arg)) ||
                                             arg instanceof J.Literal ||
                                             arg instanceof J.Identifier ||
+                                            arg instanceof J.FieldAccess ||
                                             (arg instanceof J.Binary && isOnlyLiterals((J.Binary) arg))
                     );
         }

--- a/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
@@ -123,9 +123,8 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
                     .stream()
                     .allMatch(
                             arg ->
-                                    (arg instanceof J.MethodInvocation && isSimpleGetter(arg))
-                                    || arg instanceof J.Literal
-                            );
+                                    (arg instanceof J.MethodInvocation && isSimpleGetter(arg)) ||
+                                    arg instanceof J.Literal
         }
 
         private boolean isSimpleGetter(Expression arg) {

--- a/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
@@ -71,12 +71,10 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
         @Override
         public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
             J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
-            if (
-                    m.getSelect() != null &&
-                            (infoMatcher.matches(m) || debugMatcher.matches(m) || traceMatcher.matches(m)) &&
-                            !isInIfStatementWithLogLevelCheck(getCursor(), m) &&
-                            isAnyArgumentExpensive(m)
-            ) {
+            if (m.getSelect() != null &&
+                    (infoMatcher.matches(m) || debugMatcher.matches(m) || traceMatcher.matches(m)) &&
+                    !isInIfStatementWithLogLevelCheck(getCursor(), m) &&
+                    isAnyArgumentExpensive(m)) {
                 J container = getCursor().getParentTreeCursor().getValue();
                 if (container instanceof J.Block) {
                     UUID id = container.getId();
@@ -116,59 +114,42 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
         }
 
         private boolean isAnyArgumentExpensive(J.MethodInvocation m) {
-            return !areAllArgumentsCheap(m);
-        }
-
-        private static boolean areAllArgumentsCheap(J.MethodInvocation m) {
             return m
                     .getArguments()
                     .stream()
-                    .allMatch(
-                            arg ->
-                                    (arg instanceof J.MethodInvocation && isSimpleGetter((J.MethodInvocation) arg)) ||
-                                            arg instanceof J.Literal ||
-                                            arg instanceof J.Identifier ||
-                                            arg instanceof J.FieldAccess ||
-                                            (arg instanceof J.Binary && isOnlyLiterals((J.Binary) arg))
+                    .anyMatch(arg ->
+                            !(arg instanceof J.MethodInvocation && isSimpleGetter((J.MethodInvocation) arg) ||
+                                    arg instanceof J.Literal ||
+                                    arg instanceof J.Identifier ||
+                                    arg instanceof J.FieldAccess ||
+                                    arg instanceof J.Binary && isOnlyLiterals((J.Binary) arg))
                     );
         }
 
         private static boolean isSimpleGetter(J.MethodInvocation mi) {
-            return (
-                    (mi.getSimpleName().startsWith("get") && mi.getSimpleName().length() > 3) ||
-                            (mi.getSimpleName().startsWith("is") && mi.getSimpleName().length() > 2)
-            ) &&
+            return ((mi.getSimpleName().startsWith("get") && mi.getSimpleName().length() > 3) ||
+                    (mi.getSimpleName().startsWith("is") && mi.getSimpleName().length() > 2)) &&
                     mi.getMethodType() != null &&
                     mi.getMethodType().getParameterNames().isEmpty() &&
-                    (
-                            (mi.getSelect() == null || mi.getSelect() instanceof J.Identifier) &&
-                                    !mi.getMethodType().hasFlags(Flag.Static)
-                    );
+                    ((mi.getSelect() == null || mi.getSelect() instanceof J.Identifier) &&
+                            !mi.getMethodType().hasFlags(Flag.Static));
         }
 
         private static boolean isOnlyLiterals(J.Binary binary) {
-            return isLiteralOrBinary(binary.getLeft()) &&
-                    isLiteralOrBinary(binary.getRight());
+            return isLiteralOrBinary(binary.getLeft()) && isLiteralOrBinary(binary.getRight());
         }
 
         private static boolean isLiteralOrBinary(J expression) {
-            if (expression instanceof J.Literal || isSimpleBooleanGetter(expression) || isBooleanIdentifier(expression)) {
-                return true;
-            } else if (expression instanceof J.Binary) {
-                return isOnlyLiterals((J.Binary) expression);
-            } else {
-                return false;
-            }
+            return expression instanceof J.Literal ||
+                    isSimpleBooleanGetter(expression) ||
+                    isBooleanIdentifier(expression) ||
+                    expression instanceof J.Binary && isOnlyLiterals((J.Binary) expression);
         }
 
         private static boolean isSimpleBooleanGetter(J expression) {
             if (expression instanceof J.MethodInvocation) {
                 J.MethodInvocation mi = (J.MethodInvocation) expression;
-                if (isSimpleGetter(mi) && mi.getMethodType() != null) {
-                    if (isTypeBoolean(mi.getMethodType().getReturnType())) {
-                        return true;
-                    }
-                }
+                return isSimpleGetter(mi) && mi.getMethodType() != null && isTypeBoolean(mi.getMethodType().getReturnType());
             }
             return false;
         }

--- a/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
@@ -73,9 +73,9 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
             J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
             if (
                     m.getSelect() != null &&
-                    (infoMatcher.matches(m) || debugMatcher.matches(m) || traceMatcher.matches(m)) &&
-                    !isInIfStatementWithLogLevelCheck(getCursor(), m) &&
-                    isAnyArgumentExpensive(m)
+                            (infoMatcher.matches(m) || debugMatcher.matches(m) || traceMatcher.matches(m)) &&
+                            !isInIfStatementWithLogLevelCheck(getCursor(), m) &&
+                            isAnyArgumentExpensive(m)
             ) {
                 J container = getCursor().getParentTreeCursor().getValue();
                 if (container instanceof J.Block) {
@@ -126,27 +126,28 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
                     .allMatch(
                             arg ->
                                     (arg instanceof J.MethodInvocation && isSimpleGetter((J.MethodInvocation) arg)) ||
-                                    arg instanceof J.Literal ||
-                                    arg instanceof J.Identifier ||
-                                    (arg instanceof J.Binary && isOnlyLiterals((J.Binary) arg))
+                                            arg instanceof J.Literal ||
+                                            arg instanceof J.Identifier ||
+                                            (arg instanceof J.Binary && isOnlyLiterals((J.Binary) arg))
                     );
         }
 
         private static boolean isSimpleGetter(J.MethodInvocation mi) {
             return (
-                           (mi.getSimpleName().startsWith("get") && mi.getSimpleName().length() > 3) ||
-                           (mi.getSimpleName().startsWith("is") && mi.getSimpleName().length() > 2)
-                   ) &&
-                   mi.getMethodType().getParameterNames().isEmpty() &&
-                   (
-                           (mi.getSelect() == null || mi.getSelect() instanceof J.Identifier) &&
-                           !mi.getMethodType().hasFlags(Flag.Static)
-                   );
+                    (mi.getSimpleName().startsWith("get") && mi.getSimpleName().length() > 3) ||
+                            (mi.getSimpleName().startsWith("is") && mi.getSimpleName().length() > 2)
+            ) &&
+                    mi.getMethodType() != null &&
+                    mi.getMethodType().getParameterNames().isEmpty() &&
+                    (
+                            (mi.getSelect() == null || mi.getSelect() instanceof J.Identifier) &&
+                                    !mi.getMethodType().hasFlags(Flag.Static)
+                    );
         }
 
         private static boolean isOnlyLiterals(J.Binary binary) {
             return isLiteralOrBinary(binary.getLeft()) &&
-                   isLiteralOrBinary(binary.getRight());
+                    isLiteralOrBinary(binary.getRight());
         }
 
         private static boolean isLiteralOrBinary(J expression) {
@@ -170,15 +171,14 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
             }
             return false;
         }
+
         private static boolean isBooleanIdentifier(J expression) {
             return expression instanceof J.Identifier && isTypeBoolean(((J.Identifier) expression).getType());
         }
 
-        private static boolean isTypeBoolean(JavaType type) {
-            return type == JavaType.Primitive.Boolean ||
-                   (type instanceof JavaType.FullyQualified && "java.lang.Boolean".equals(((JavaType.FullyQualified) type).getFullyQualifiedName()));
+        private static boolean isTypeBoolean(@Nullable JavaType type) {
+            return type == JavaType.Primitive.Boolean || TypeUtils.isAssignableTo("java.lang.Boolean", type);
         }
-
     }
 
     @EqualsAndHashCode(callSuper = false)

--- a/src/test/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionalsTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionalsTest.java
@@ -17,16 +17,13 @@ package org.openrewrite.java.logging.slf4j;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
-
-import java.util.stream.Stream;
 
 import static org.openrewrite.java.Assertions.java;
 
@@ -585,24 +582,20 @@ class WrapExpensiveLogStatementsInConditionalsTest implements RewriteTest {
         );
     }
 
-    private static Stream<Arguments> wrapWhenExpensiveArgument() {
-        return Stream.of(
-          Arguments.of("notAGetter()"), // not a getter
-          Arguments.of("new A()"), // allocating a new object
-          Arguments.of("new A().getClass()"), // allocating a new object first
-          Arguments.of("\"foo\".getBytes()"), // allocating a string first
-          Arguments.of("input.getBytes(StandardCharsets.UTF_16)"), // getter with an argument
-          Arguments.of("getClass().getName()"), // getter on a method invocation expression
-          Arguments.of("optional.get()"), // not a getter
-          Arguments.of("A.getExpensive()"), // static getter likely to use external resources or allocate things
-          Arguments.of("getExpensive()"), // static getter likely to use external resources or allocate things
-          Arguments.of("342 + input"), // allocating a new string
-          Arguments.of("\"foo\" + getClass()"), // allocating a new string
-          Arguments.of("true && isSomething(1)")
-        );
-    }
-
-    @MethodSource
+    @ValueSource(strings = {
+      "notAGetter()", // not a getter
+      "new A()", // allocating a new object
+      "new A().getClass()", // allocating a new object first
+      "\"foo\".getBytes()", // allocating a string first
+      "input.getBytes(StandardCharsets.UTF_16)", // getter with an argument
+      "getClass().getName()", // getter on a method invocation expression
+      "optional.get()", // not a getter
+      "A.getExpensive()", // static getter likely to use external resources or allocate things
+      "getExpensive()", // static getter likely to use external resources or allocate things
+      "342 + input", // allocating a new string
+      "\"foo\" + getClass()", // allocating a new string
+      "true && isSomething(1)"
+    })
     @ParameterizedTest
     void wrapWhenExpensiveArgument(String logArgument) {
         //language=java
@@ -660,24 +653,19 @@ class WrapExpensiveLogStatementsInConditionalsTest implements RewriteTest {
         );
     }
 
-    private static Stream<Arguments> dontWrapWhenCheapArgument() {
-        // We don't allocate stuff or very unlikely:
-        return Stream.of(
-          Arguments.of("input"), // identifier alone
-          Arguments.of("getClass()"), // a getter
-          Arguments.of("log.getName()"), // a getter
-          Arguments.of("34 + 78"), // literal
-          Arguments.of("8344"), // literal
-          Arguments.of("\"like, literally!\""), // literal
-          Arguments.of("\"one\" + \"two\" + \"three\""), // compile time literal
-          Arguments.of("\"one\" + 1"), // compile time literal
-          Arguments.of("true && false"), // boolean literal
-          Arguments.of("true && isSomething()"), // boolean literal and boolean getter
-          Arguments.of("true && boolVariable || isSomething()") // boolean literal and boolean variable
-        );
-    }
-
-    @MethodSource
+    @ValueSource(strings = {
+      "input", // identifier alone
+      "getClass()", // a getter
+      "log.getName()", // a getter
+      "34 + 78", // literal
+      "8344", // literal
+      "\"like, literally!\"", // literal
+      "\"one\" + \"two\" + \"three\"", // compile time literal
+      "\"one\" + 1", // compile time literal
+      "true && false", // boolean literal
+      "true && isSomething()", // boolean literal and boolean getter
+      "true && boolVariable || isSomething()" // boolean literal and boolean variable
+    })
     @ParameterizedTest
     void dontWrapWhenCheapArgument(String logArgument) {
         //language=java

--- a/src/test/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionalsTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionalsTest.java
@@ -664,7 +664,9 @@ class WrapExpensiveLogStatementsInConditionalsTest implements RewriteTest {
       "\"one\" + 1", // compile time literal
       "true && false", // boolean literal
       "true && isSomething()", // boolean literal and boolean getter
-      "true && boolVariable || isSomething()" // boolean literal and boolean variable
+      "true && boolVariable || isSomething()", // boolean literal and boolean variable
+      "field", // field identifier
+      "this.field", // field access
     })
     @ParameterizedTest
     void dontWrapWhenCheapArgument(String logArgument) {
@@ -675,6 +677,8 @@ class WrapExpensiveLogStatementsInConditionalsTest implements RewriteTest {
               import org.slf4j.Logger;
 
               class A {
+                  String field;
+
                   void method(Logger log, String input, boolean boolVariable) {
                       log.info("{}", %s);
                   }

--- a/src/test/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionalsTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionalsTest.java
@@ -586,7 +586,6 @@ class WrapExpensiveLogStatementsInConditionalsTest implements RewriteTest {
       "notAGetter()", // not a getter
       "new A()", // allocating a new object
       "new A().getClass()", // allocating a new object first
-      "\"foo\".getBytes()", // allocating a string first
       "input.getBytes(StandardCharsets.UTF_16)", // getter with an argument
       "getClass().getName()", // getter on a method invocation expression
       "optional.get()", // not a getter
@@ -594,7 +593,7 @@ class WrapExpensiveLogStatementsInConditionalsTest implements RewriteTest {
       "getExpensive()", // static getter likely to use external resources or allocate things
       "342 + input", // allocating a new string
       "\"foo\" + getClass()", // allocating a new string
-      "true && isSomething(1)"
+      "true && isSomething(1)" // boolean getter with an argument
     })
     @ParameterizedTest
     void wrapWhenExpensiveArgument(String logArgument) {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
`WrapExpensiveLogStatementsInConditionals` is now checking if all log call arguments are getters. When they are, those operations are considered inexpensive and the log call is left as is, unwrapped.

## What's your motivation?
- Fix #232 

## Anyone you would like to review specifically?
@timtebeek 
@greg-at-moderne

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
