### PR TITLE
Adds filePattern parameter to ConfigureLoggerLevel

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/logback/ConfigureLoggerLevel.java
+++ b/src/main/java/org/openrewrite/java/logging/logback/ConfigureLoggerLevel.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.logging.logback;
 
 import lombok.EqualsAndHashCode;
 import lombok.Value;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.xml.XPathMatcher;
@@ -29,6 +30,8 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = false)
 @Value
 public class ConfigureLoggerLevel extends Recipe {
+
+    public static final String DEFAULT_FILE = "**/logback.xml";
 
     @Override
     public String getDisplayName() {
@@ -52,6 +55,16 @@ public class ConfigureLoggerLevel extends Recipe {
             example = "off")
     LogLevel logLevel;
 
+    @Option(displayName = "File pattern",
+            description = "A glob expression that can be used to constrain which directories or source files should be searched. " +
+                          "Multiple patterns may be specified, separated by a semicolon `;`. " +
+                          "If multiple patterns are supplied any of the patterns matching will be interpreted as a match. " +
+                          "When not set, '**/logback.xml' is used.",
+            required = false,
+            example = "**/logback-spring.xml")
+    @Nullable
+    String filePattern;
+
     public enum LogLevel {
         trace,
         debug,
@@ -63,7 +76,7 @@ public class ConfigureLoggerLevel extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(new FindSourceFiles("**/logback.xml"), new XmlIsoVisitor<ExecutionContext>() {
+        return Preconditions.check(new FindSourceFiles(filePattern == null ? DEFAULT_FILE : filePattern), new XmlIsoVisitor<ExecutionContext>() {
 
             @Override
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {

--- a/src/test/java/org/openrewrite/java/logging/logback/ConfigureLoggerLevelTest.java
+++ b/src/test/java/org/openrewrite/java/logging/logback/ConfigureLoggerLevelTest.java
@@ -27,7 +27,7 @@ class ConfigureLoggerLevelTest implements RewriteTest {
     @Test
     void editExistingLogger() {
         rewriteRun(
-          spec -> spec.recipe(new ConfigureLoggerLevel("org.springframework", ConfigureLoggerLevel.LogLevel.off)),
+          spec -> spec.recipe(new ConfigureLoggerLevel("org.springframework", ConfigureLoggerLevel.LogLevel.off, null)),
           xml(//language=xml
             """
               <configuration>
@@ -67,7 +67,7 @@ class ConfigureLoggerLevelTest implements RewriteTest {
     @Test
     void addNewLogger() {
         rewriteRun(
-            spec -> spec.recipe(new ConfigureLoggerLevel("com.example.MyClass", ConfigureLoggerLevel.LogLevel.off)),
+            spec -> spec.recipe(new ConfigureLoggerLevel("com.example.MyClass", ConfigureLoggerLevel.LogLevel.off, null)),
           xml(//language=xml
             """
               <configuration>
@@ -102,6 +102,47 @@ class ConfigureLoggerLevelTest implements RewriteTest {
               </configuration>
               """,
             spec -> spec.path("logback.xml"))
+        );
+    }
+
+    @Test
+    void logbackSpring() {
+        rewriteRun(
+          spec -> spec.recipe(new ConfigureLoggerLevel("com.example.MyClass", ConfigureLoggerLevel.LogLevel.off, "**/logback-spring.xml")),
+          xml(//language=xml
+            """
+              <configuration>
+                  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                      <layout class="ch.qos.logback.classic.PatternLayout">
+                          <Pattern>
+                              %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+                          </Pattern>
+                      </layout>
+                  </appender>
+
+                  <logger name="org.springframework" level="error" additivity="false">
+                      <appender-ref ref="STDOUT" />
+                  </logger>
+              </configuration>
+              """,
+            //language=xml
+            """
+              <configuration>
+                  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                      <layout class="ch.qos.logback.classic.PatternLayout">
+                          <Pattern>
+                              %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+                          </Pattern>
+                      </layout>
+                  </appender>
+
+                  <logger name="org.springframework" level="error" additivity="false">
+                      <appender-ref ref="STDOUT" />
+                  </logger>
+                  <logger name="com.example.MyClass" level="off"/>
+              </configuration>
+              """,
+            spec -> spec.path("logback-spring.xml"))
         );
     }
 }


### PR DESCRIPTION
Sometimes logback configurations are not named
logback.xml. Added an optional parameter to make
the recipe usable in these cases as well.

- Resolves #234
