### PR TITLE
Fix Slf4jLogShouldBeConstant to preserve format specifiers with width, alignment, and precision.

### DIFF
--- a/src/test/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstantTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/Slf4jLogShouldBeConstantTest.java
@@ -49,15 +49,6 @@ class Slf4jLogShouldBeConstantTest implements RewriteTest {
                       log.info(String.format("The first argument is '%d', and the second argument is '%.2f'.", 1, 2.3333));
                   }
               }
-              """,
-            """
-              import org.slf4j.Logger;
-              class A {
-                  Logger log;
-                  void method() {
-                      log.info("The first argument is '{}', and the second argument is '{}'.", 1, 2.3333);
-                  }
-              }
               """
           )
         );
@@ -372,4 +363,57 @@ class Slf4jLogShouldBeConstantTest implements RewriteTest {
         );
     }
 
+    @Test
+    void noChangeWithWidth() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.slf4j.Logger;
+              class A {
+                  Logger log;
+                  void method() {
+                      log.info(String.format("%10s", "test"));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noChangeWithLeftAlignment() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.slf4j.Logger;
+              class A {
+                  Logger log;
+                  void method() {
+                      log.info(String.format("%-10s", "test"));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noChangeWithPrecision() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.slf4j.Logger;
+              class A {
+                  Logger log;
+                  void method() {
+                      log.info(String.format("%.2f", 1.2345));
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
This PR changes the behavior of the `Slf4jLogShouldBeConstant` recipe where it was converting `String.format()` calls that contained format specifiers with width, alignment, or precision modifiers.

## What's your motivation?
The recipe was stripping all formatting information, breaking columnar output in logs.

## Anything in particular you'd like reviewers to focus on?
The new regex could use scrutiny.

## Have you considered any alternatives or workarounds?
For recipe groups like CommonStaticAnalysis, I [split it up](https://github.com/liftwizard/liftwizard/blob/5c3f313a59cf3ee4e7e3967df80c6e80778da3fb/liftwizard-maven-build/liftwizard-profile-parent/pom.xml#L129) and remove the problematic recipes, but this one is a leaf.

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
As I was preparing this PR, I saw #238 and I figured I'd get this out quicker for discussion. The main thing I was surprised at is the other PR title makes it sound like String.format strings are not getting changed at all, but I see them getting changed in a way that is not valid.

- Closes https://github.com/openrewrite/rewrite-logging-frameworks/pull/238

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files

(but there are other formatting violations in the same files that I touched)