### PR TITLE
LoggerLevelArgumentToMethod for JBoss Logging

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     }
     testRuntimeOnly("log4j:log4j:1.+") // Necessary to match for now; explore alternatives for Refaster classpath in the future
     testRuntimeOnly("ch.qos.logback:logback-classic:1.3.+")
+    testRuntimeOnly("org.jboss.logging:jboss-logging:3.+")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.+")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.+")

--- a/src/main/java/org/openrewrite/java/logging/jboss/LoggerLevelArgumentToMethod.java
+++ b/src/main/java/org/openrewrite/java/logging/jboss/LoggerLevelArgumentToMethod.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.logging.jboss;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class LoggerLevelArgumentToMethod extends Recipe {
+    private static final MethodMatcher LOG_MATCHER = new MethodMatcher("org.jboss.logging.Logger log(..)", true);
+    private static final MethodMatcher LOGF_MATCHER = new MethodMatcher("org.jboss.logging.Logger logf(..)", true);
+    private static final MethodMatcher LOGV_MATCHER = new MethodMatcher("org.jboss.logging.Logger logv(..)", true);
+
+    @Override
+    public String getDisplayName() {
+        return "Replace JBoss Logging Level arguments with the corresponding eponymous level method calls";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace calls to `Logger.log(Level, ...)` with the corresponding eponymous level method calls. For example `Logger.log(Level.INFO, ...)` to `Logger.info(...)`.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        JavaVisitor<ExecutionContext> javaVisitor = new JavaIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation mi, ExecutionContext ctx) {
+                J.MethodInvocation m = super.visitMethodInvocation(mi, ctx);
+                if (!(LOG_MATCHER.matches(m) || LOGF_MATCHER.matches(m) || LOGV_MATCHER.matches(m))) {
+                    return m;
+                }
+                List<Expression> args = m.getArguments();
+                Expression firstArgument = requireNonNull(args.get(0));
+                Expression secondArgument = requireNonNull(args.get(1));
+
+                String formatted = "";
+                if (LOGF_MATCHER.matches(m) || LOGV_MATCHER.matches(m)) {
+                    if (TypeUtils.isAssignableTo("java.lang.String", firstArgument.getType())) {
+                        // `logger.logf(String fqcn ...)` and `logger.logv(String fqcn ...)` don't have a logger.level() equivalent.
+                        return m;
+                    }
+                    formatted = m.getSimpleName().substring(m.getSimpleName().length() - 1);
+                }
+
+                String logLevelName;
+                List<Expression> updatedArguments;
+                if (TypeUtils.isAssignableTo("org.jboss.logging.Logger.Level", firstArgument.getType())) {
+                    // void log,logf,logv(Logger.Level level, **);
+                    logLevelName = extractLogLevelName(firstArgument) + formatted;
+                    updatedArguments = ListUtils.concat(
+                            (Expression) secondArgument.withPrefix(firstArgument.getPrefix()),
+                            args.subList(2, args.size()));
+                } else if (TypeUtils.isAssignableTo("java.lang.String", firstArgument.getType()) &&
+                           TypeUtils.isAssignableTo("org.jboss.logging.Logger.Level", secondArgument.getType())) {
+                    // void log(String loggerFqcn, Logger.Level level, Object message, Object[] params, Throwable t);
+                    logLevelName = extractLogLevelName(secondArgument);
+                    updatedArguments = ListUtils.filter(args, arg -> arg != secondArgument);
+                } else {
+                    return m;
+                }
+
+                JavaType.Method updatedMethodType = requireNonNull(m.getMethodType())
+                        .withParameterTypes(ListUtils.filter(requireNonNull(m.getMethodType()).getParameterTypes(), type -> !TypeUtils.isAssignableTo("org.jboss.logging.Logger.Level", type)))
+                        .withParameterNames(ListUtils.filter(m.getMethodType().getParameterNames(), name -> !"level".equals(name)))
+                        .withName(logLevelName.toLowerCase());
+
+                return m
+                        .withArguments(updatedArguments)
+                        .withMethodType(updatedMethodType)
+                        .withName(m.getName().withSimpleName(logLevelName.toLowerCase()));
+            }
+
+            String extractLogLevelName(Expression expression) {
+                if (expression instanceof J.Identifier) {
+                    return ((J.Identifier) expression).getSimpleName();
+                }
+                return ((J.FieldAccess) expression).getSimpleName();
+            }
+        };
+        return Preconditions.check(
+                Preconditions.and(
+                        new UsesType<>("org.jboss.logging.Logger", true),
+                        new UsesType<>("org.jboss.logging.Logger.Level", true),
+                        Preconditions.or(
+                                new UsesMethod<>(LOG_MATCHER),
+                                new UsesMethod<>(LOGF_MATCHER),
+                                new UsesMethod<>(LOGV_MATCHER)
+                        )
+                ),
+                javaVisitor
+        );
+    }
+
+}

--- a/src/test/java/org/openrewrite/java/logging/jboss/LoggerLevelArgumentToMethodTest.java
+++ b/src/test/java/org/openrewrite/java/logging/jboss/LoggerLevelArgumentToMethodTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.logging.jboss;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class LoggerLevelArgumentToMethodTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new LoggerLevelArgumentToMethod());
+    }
+
+    @DocumentExample
+    @ParameterizedTest
+    @ValueSource(strings = {"trace", "debug", "info", "warn", "error", "fatal"})
+    void replaceLevelArguments(String level) {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.jboss.logging.Logger;
+
+              import static org.jboss.logging.Logger.Level.%1$S;
+
+              class Test {
+                  void test(Logger logger, Object msg, Throwable t, String fqcn) {
+                      logger.log(Logger.Level.%1$S, msg);
+                      logger.log(%1$S, msg);
+                      logger.log(Logger.Level.%1$S, msg, t);
+                      logger.log(Logger.Level.%1$S, fqcn, msg, t);
+                      logger.log(Logger.Level.%1$S, msg, new String[]{"msg"});
+                      logger.log(Logger.Level.%1$S, msg, new String[]{"msg"}, t);
+                      logger.log(fqcn, Logger.Level.%1$S, msg, new String[]{"msg"}, t);
+                  }
+              }
+              """.formatted(level),
+            """
+              import org.jboss.logging.Logger;
+
+              import static org.jboss.logging.Logger.Level.%1$S;
+
+              class Test {
+                  void test(Logger logger, Object msg, Throwable t, String fqcn) {
+                      logger.%1$s(msg);
+                      logger.%1$s(msg);
+                      logger.%1$s(msg, t);
+                      logger.%1$s(fqcn, msg, t);
+                      logger.%1$s(msg, new String[]{"msg"});
+                      logger.%1$s(msg, new String[]{"msg"}, t);
+                      logger.%1$s(fqcn, msg, new String[]{"msg"}, t);
+                  }
+              }
+              """.formatted(level)
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"trace", "debug", "info", "warn", "error", "fatal"})
+    void replaceLevelArgumentsFormatF(String level) {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.jboss.logging.Logger;
+
+              import static org.jboss.logging.Logger.Level.%1$S;
+
+              class Test {
+                  void test(Logger logger, String msg, Throwable t, String fqcn, Object[] p) {
+                      logger.logf(Logger.Level.%1$S, msg, p[0]);
+                      logger.logf(Logger.Level.%1$S, msg, p[0], p[1]);
+                      logger.logf(Logger.Level.%1$S, msg, p[0], p[2], p[3]);
+                      logger.logf(Logger.Level.%1$S, msg, p[0], p[2], p[3], p[4]);
+
+                      logger.logf(Logger.Level.%1$S, t, msg, p[0]);
+                      logger.logf(Logger.Level.%1$S, t, msg, p[0], p[1]);
+                      logger.logf(Logger.Level.%1$S, t, msg, p[0], p[2], p[3]);
+                      logger.logf(Logger.Level.%1$S, t, msg, p[0], p[2], p[3], p[4]);
+
+                      logger.logf(fqcn, Logger.Level.%1$S, t, msg, p[0]);
+                  }
+              }
+              """.formatted(level),
+            """
+              import org.jboss.logging.Logger;
+
+              import static org.jboss.logging.Logger.Level.%1$S;
+
+              class Test {
+                  void test(Logger logger, String msg, Throwable t, String fqcn, Object[] p) {
+                      logger.%1$sf(msg, p[0]);
+                      logger.%1$sf(msg, p[0], p[1]);
+                      logger.%1$sf(msg, p[0], p[2], p[3]);
+                      logger.%1$sf(msg, p[0], p[2], p[3], p[4]);
+
+                      logger.%1$sf(t, msg, p[0]);
+                      logger.%1$sf(t, msg, p[0], p[1]);
+                      logger.%1$sf(t, msg, p[0], p[2], p[3]);
+                      logger.%1$sf(t, msg, p[0], p[2], p[3], p[4]);
+
+                      logger.logf(fqcn, Logger.Level.%1$S, t, msg, p[0]);
+                  }
+              }
+              """.formatted(level)
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"trace", "debug", "info", "warn", "error", "fatal"})
+    void replaceLevelArgumentsFormatV(String level) {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.jboss.logging.Logger;
+
+              import static org.jboss.logging.Logger.Level.%1$S;
+
+              class Test {
+                  void test(Logger logger, String msg, Throwable t, String fqcn, Object[] p) {
+                      logger.logv(Logger.Level.%1$S, msg, p[0]);
+                      logger.logv(Logger.Level.%1$S, msg, p[0], p[1]);
+                      logger.logv(Logger.Level.%1$S, msg, p[0], p[2], p[3]);
+                      logger.logv(Logger.Level.%1$S, msg, p[0], p[2], p[3], p[4]);
+
+                      logger.logv(Logger.Level.%1$S, t, msg, p[0]);
+                      logger.logv(Logger.Level.%1$S, t, msg, p[0], p[1]);
+                      logger.logv(Logger.Level.%1$S, t, msg, p[0], p[2], p[3]);
+                      logger.logv(Logger.Level.%1$S, t, msg, p[0], p[2], p[3], p[4]);
+
+                      logger.logv(fqcn, Logger.Level.%1$S, t, msg, p[0]);
+                  }
+              }
+              """.formatted(level),
+            """
+              import org.jboss.logging.Logger;
+
+              import static org.jboss.logging.Logger.Level.%1$S;
+
+              class Test {
+                  void test(Logger logger, String msg, Throwable t, String fqcn, Object[] p) {
+                      logger.%1$sv(msg, p[0]);
+                      logger.%1$sv(msg, p[0], p[1]);
+                      logger.%1$sv(msg, p[0], p[2], p[3]);
+                      logger.%1$sv(msg, p[0], p[2], p[3], p[4]);
+
+                      logger.%1$sv(t, msg, p[0]);
+                      logger.%1$sv(t, msg, p[0], p[1]);
+                      logger.%1$sv(t, msg, p[0], p[2], p[3]);
+                      logger.%1$sv(t, msg, p[0], p[2], p[3], p[4]);
+
+                      logger.logv(fqcn, Logger.Level.%1$S, t, msg, p[0]);
+                  }
+              }
+              """.formatted(level)
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
New recipe to replace calls to `Logger.log(Level, ...)` with the corresponding eponymous level method calls. For example `Logger.log(Level.INFO, ...)` to `Logger.info(...)`.";

## What's your motivation?
This is a sub-recipe to the more general [JBoss Logging migration to SLF4J declarative recipe](https://github.com/openrewrite/rewrite-logging-frameworks/pull/241).
* This recipe is a step to normalize the code before applying the actual migration recipes.
* The other migration recipes will be able to focus on migrating only the `logger.loglevel()` invocations and be simpler than if they had to additionally support the various `logger.log()`, `logger.logv()` and `logger.logf()`.
* This recipe is also usable independently.

## Anything in particular you'd like reviewers to focus on?

## Anyone you would like to review specifically?

## Have you considered any alternatives or workarounds?

## Any additional context
* Based on a [similar recipe for JUL](https://github.com/openrewrite/rewrite-logging-frameworks/blob/main/src/main/java/org/openrewrite/java/logging/jul/LoggerLevelArgumentToMethod.java)
* Using imperative recipe instead of refaster or declarative because:
    * There's 108 combinations that'd require 108 refaster sub-recipes.
    * A declarative version would be very verbose and harder to read/maintain than the imperative version.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
