### PR TITLE
Avoid unsafe changes in `JulParameterizedArguments` when `JavaType.Array` argument is not a `J.NewArray`

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/slf4j/JulParameterizedArguments.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/JulParameterizedArguments.java
@@ -92,6 +92,11 @@ public class JulParameterizedArguments extends Recipe {
                 Expression messageArgument = originalArguments.get(1);
                 Expression stringFormatArgument = originalArguments.get(2);
 
+                if (stringFormatArgument.getType() instanceof JavaType.Array &&
+                        !(stringFormatArgument instanceof J.NewArray)) {
+                    return method;
+                }
+
                 if (!(levelArgument instanceof J.FieldAccess || levelArgument instanceof J.Identifier) ||
                         !isStringLiteral(messageArgument)) {
                     return method;

--- a/src/main/java/org/openrewrite/java/logging/slf4j/JulParameterizedArguments.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/JulParameterizedArguments.java
@@ -37,6 +37,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.openrewrite.Tree.randomId;
 
 public class JulParameterizedArguments extends Recipe {
@@ -145,7 +146,7 @@ public class JulParameterizedArguments extends Recipe {
                     }
                     return arrayAccessExpr;
                 }
-                return Collections.singletonList(arrayExpression);
+                return singletonList(arrayExpression);
             }
 
             private List<Integer> originalLoggedArgumentIndices(String strFormat) {

--- a/src/test/java/org/openrewrite/java/logging/slf4j/JulParameterizedArgumentsTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/JulParameterizedArgumentsTest.java
@@ -89,6 +89,34 @@ class JulParameterizedArgumentsTest implements RewriteTest {
     }
 
     @Test
+    void parameterizedArgumentArrayWithNoInitializer() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import java.util.logging.Level;
+              import java.util.logging.Logger;
+
+              class Test {
+                  void method(Logger logger) {
+                      logger.log(Level.INFO, "INFO Log entry", new String[]{});
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+
+              class Test {
+                  void method(Logger logger) {
+                      logger.info("INFO Log entry");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void retainLoggedArgumentOrder() {
         rewriteRun(
           // language=java

--- a/src/test/java/org/openrewrite/java/logging/slf4j/JulParameterizedArgumentsTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/JulParameterizedArgumentsTest.java
@@ -159,16 +159,6 @@ class JulParameterizedArgumentsTest implements RewriteTest {
                       logger.log(Level.INFO, "INFO Log entry, param1: {0}, param2: {1}, etc", params);
                   }
               }
-              """,
-            """
-              import org.slf4j.Logger;
-
-              class Test {
-                  void method(Logger logger, String[] params) {
-                      logger.info("INFO Log entry, param2: {}, param1: {}, etc", params[1], params[0]);
-                      logger.info("INFO Log entry, param1: {}, param2: {}, etc", params[0], params[1]);
-                  }
-              }
               """
           )
         );

--- a/src/test/java/org/openrewrite/java/logging/slf4j/JulParameterizedArgumentsTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/JulParameterizedArgumentsTest.java
@@ -15,8 +15,10 @@
  */
 package org.openrewrite.java.logging.slf4j;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -144,6 +146,8 @@ class JulParameterizedArgumentsTest implements RewriteTest {
         );
     }
 
+    @Disabled("Skipped by `JulParameterizedArguments`, but incomplete changes seen from JUL -> Log4j -> Slf4j")
+    @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/pull/244#issuecomment-3140661425")
     @Test
     void arrayIdentifierArgument() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/logging/slf4j/JulParameterizedArgumentsTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/JulParameterizedArgumentsTest.java
@@ -117,6 +117,36 @@ class JulParameterizedArgumentsTest implements RewriteTest {
     }
 
     @Test
+    void arrayIdentifierArgument() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import java.util.logging.Level;
+              import java.util.logging.Logger;
+
+              class Test {
+                  void method(Logger logger, String[] params) {
+                      logger.log(Level.INFO, "INFO Log entry, param2: {1}, param1: {0}, etc", params);
+                      logger.log(Level.INFO, "INFO Log entry, param1: {0}, param2: {1}, etc", params);
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+
+              class Test {
+                  void method(Logger logger, String[] params) {
+                      logger.info("INFO Log entry, param2: {}, param1: {}, etc", params[1], params[0]);
+                      logger.info("INFO Log entry, param1: {}, param2: {}, etc", params[0], params[1]);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void repeatLoggedArgumentAsNeeded() {
         rewriteRun(
           // language=java


### PR DESCRIPTION
## What's changed?
The `org.openrewrite.java.logging.slf4j.JulParameterizedArguments` recipe now supports migrating `JUL.log("{0}", arrayIdentifier)` to SLF4J.
Before that the only supported form was: `JUL.log("{0}", new String[]{"foo"})`.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
