### PR TITLE
Update SLF4J JBoss Logmanager version to 2.0.2.Final

### DIFF
--- a/src/test/java/org/openrewrite/java/logging/slf4j/JBossLoggingToSlf4jTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/JBossLoggingToSlf4jTest.java
@@ -177,7 +177,7 @@ class JBossLoggingToSlf4jTest implements RewriteTest {
                             <dependency>
                                 <groupId>org.jboss.slf4j</groupId>
                                 <artifactId>slf4j-jboss-logmanager</artifactId>
-                                <version>2.0.1.Final</version>
+                                <version>2.0.2.Final</version>
                             </dependency>
                         </dependencies>
                     </project>
@@ -208,7 +208,7 @@ class JBossLoggingToSlf4jTest implements RewriteTest {
                     repositories { mavenCentral() }
                     dependencies {
                         implementation "org.jboss.logmanager:jboss-logmanager:3.1.2.Final"
-                        implementation "org.jboss.slf4j:slf4j-jboss-logmanager:2.0.1.Final"
+                        implementation "org.jboss.slf4j:slf4j-jboss-logmanager:2.0.2.Final"
                     }
                     """
                 )


### PR DESCRIPTION
## What's changed?

Changing `JBossLoggingToSlf4jTest` to expect `2.0.2` of `slf4j-jboss-logmanager`.
After a new version has been released.

## What's your motivation?

Fix broken CI.