### PR TITLE
fixed spacing after sequential javaTemplate runs using the same cursor 

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/ParameterizedLogging.java
+++ b/src/main/java/org/openrewrite/java/logging/ParameterizedLogging.java
@@ -163,7 +163,6 @@ public class ParameterizedLogging extends Recipe {
                     if (Boolean.TRUE.equals(removeToString)) {
                         m = m.withArguments(ListUtils.map(m.getArguments(), arg -> (Expression) removeToStringVisitor.visitNonNull(arg, ctx, getCursor())));
                     }
-                    m = maybeAutoFormat(method, m, ctx);
                 }
 
                 // Avoid changing reference if the templating didn't actually change the contents of the method
@@ -182,7 +181,6 @@ public class ParameterizedLogging extends Recipe {
     }
 
     private static class RemoveToStringVisitor extends JavaVisitor<ExecutionContext> {
-        private final JavaTemplate t = JavaTemplate.builder("#{any(java.lang.String)}").build();
         private final MethodMatcher TO_STRING = new MethodMatcher("*..* toString()");
 
         @Override
@@ -192,8 +190,8 @@ public class ParameterizedLogging extends Recipe {
             }
             if (TO_STRING.matches(method.getSelect())) {
                 getCursor().putMessage("DO_NOT_REMOVE", Boolean.TRUE);
-            } else if (TO_STRING.matches(method)) {
-                return t.apply(getCursor(), method.getCoordinates().replace(), method.getSelect());
+            } else if (TO_STRING.matches(method) && method.getSelect() != null) {
+                return method.getSelect().withPrefix(method.getPrefix());
             }
             return super.visitMethodInvocation(method, ctx);
         }


### PR DESCRIPTION
Identified an issue in the formatting of 2 sequential JavaTemplate runs where template 1 uses the return value of the previous one as cursors of parents will still contain old elements in containers etc... 
For now circumventing this by autoformatting the entire methodinvocation in the end. 