### PR TITLE
Renew log4j 1.2.17 reference suppression to 2026-06-01

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2026-05-01Z">
+    <suppress until="2026-06-01Z">
         <notes><![CDATA[
     file name: log4j-1.2.17.jar
        sev: CRITICAL


### PR DESCRIPTION
## Summary

The suppression for the log4j 1.2.17 reference jar expired on 2026-05-01. The jar is shipped only so the migration recipe can identify the legacy log4j artifact — it isn't loaded at runtime, so the CRITICAL CVEs against it remain non-exploitable in this context. Renewed `until="2026-06-01Z"`.

- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1054

## Test plan
- [x] xmllint validates suppressions.xml
- [ ] Next dependency-check scan no longer flags log4j 1.2.17 CVEs in this repo