### PR TITLE
Preserve formatting when ParameterizedLogging has nothing to parameterize

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/ParameterizedLogging.java
+++ b/src/main/java/org/openrewrite/java/logging/ParameterizedLogging.java
@@ -99,6 +99,12 @@ public class ParameterizedLogging extends Recipe {
                             }
                         }
 
+                        // Nothing to parameterize when the message is just concatenated string literals;
+                        // skip to preserve the original formatting (e.g. line breaks between literals).
+                        if (concatenationArgs.isEmpty()) {
+                            return m;
+                        }
+
                         // Check if any of the concatenation arguments is a throwable
                         // If so, skip parameterization to preserve exception handling behavior
                         boolean hasThrowableInConcatenation = concatenationArgs.stream()

--- a/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/ParameterizedLoggingTest.java
@@ -662,6 +662,29 @@ class ParameterizedLoggingTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/289")
+    @Test
+    void preserveNewlinesWhenMessageAlreadyParameterized() {
+        rewriteRun(
+          spec -> spec.recipe(new ParameterizedLogging("org.slf4j.Logger error(..)", false)),
+          //language=java
+          java(
+            """
+              import org.slf4j.Logger;
+
+              class Test {
+                  static void method(Logger logger, java.util.UUID uid) {
+                      logger.error(
+                              "No SearchContext registered for database '{}'. Returning inert fallback. "
+                                      + "LibraryTab should register one via setSearchContext on open.",
+                              uid);
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/159")
     @Test
     void concatenationWithMarker() {


### PR DESCRIPTION
- Fixes #289.

When the log message is a `J.Binary` of only string literals (i.e. an already-parameterized message split across multiple lines), the recipe previously rebuilt the call through `JavaTemplate`, which collapsed the original newlines onto a single line. Now it returns early when no expressions need to be extracted from the concatenation, preserving the source formatting. Added a regression test reproducing the example from the issue.