### PR TITLE
Fix re-escaping of control characters when rebuilding Java string literals in logging recipes.

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/internal/JavaStringEscapes.java
+++ b/src/main/java/org/openrewrite/java/logging/internal/JavaStringEscapes.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.logging.internal;
+
+public final class JavaStringEscapes {
+
+    private JavaStringEscapes() {
+    }
+
+    /**
+     * Escapes a decoded {@link String} value so it can be placed verbatim between the double quotes of a Java string
+     * literal. Printable characters, including non-ASCII text such as {@code café} or emoji, are left untouched;
+     * only the characters that would otherwise produce invalid or unreadable source are escaped.
+     *
+     * @param value the decoded string value (escape sequences already resolved to their characters)
+     * @return the escaped literal content, without surrounding quotes
+     */
+    public static String escapeJavaStringContent(String value) {
+        StringBuilder sb = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\b':
+                    sb.append("\\b");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\f':
+                    sb.append("\\f");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                default:
+                    if (Character.isISOControl(c)) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/openrewrite/java/logging/slf4j/AbstractFormatToParameterizedLogging.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/AbstractFormatToParameterizedLogging.java
@@ -22,6 +22,7 @@ import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.logging.internal.JavaStringEscapes;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -158,7 +159,7 @@ public abstract class AbstractFormatToParameterizedLogging extends Recipe {
                         originalFormatArg.getPrefix(),
                         originalFormatArg.getMarkers(),
                         slf4jTemplate,
-                        "\"" + slf4jTemplate.replace("\\", "\\\\").replace("\"", "\\\"") + "\"",
+                        "\"" + JavaStringEscapes.escapeJavaStringContent(slf4jTemplate) + "\"",
                         null,
                         JavaType.Primitive.String
                 );

--- a/src/main/java/org/openrewrite/java/logging/slf4j/JulParameterizedArguments.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/JulParameterizedArguments.java
@@ -26,6 +26,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.logging.ArgumentArrayToVarargs;
+import org.openrewrite.java.logging.internal.JavaStringEscapes;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.*;
 
@@ -60,15 +61,6 @@ public class JulParameterizedArguments extends Recipe {
 
         public static boolean isStringLiteral(Expression expression) {
             return expression instanceof J.Literal && TypeUtils.isString(((J.Literal) expression).getType());
-        }
-
-        /**
-         * Escapes special characters in a string so it can be safely used as content
-         * inside a Java string literal in a JavaTemplate.
-         */
-        private static String escapeForJavaStringLiteral(String s) {
-            // Order matters: escape backslashes first to avoid double-escaping
-            return s.replace("\\", "\\\\").replace("\"", "\\\"");
         }
 
         private static @Nullable String getMethodIdentifier(Expression levelArgument) {
@@ -133,7 +125,7 @@ public class JulParameterizedArguments extends Recipe {
                             .withType(((JavaType.Array) requireNonNull(newArray.getType())).withElemType(JavaType.ShallowClass.build("java.lang.Object")));
                 }
 
-                String slf4jFormatString = escapeForJavaStringLiteral(originalFormatString.replaceAll("\\{\\d*}", "{}"));
+                String slf4jFormatString = JavaStringEscapes.escapeJavaStringContent(originalFormatString.replaceAll("\\{\\d*}", "{}"));
                 J.MethodInvocation updatedMi = JavaTemplate.apply(newName + "(\"#{}\",#{anyArray(Object)})", getCursor(), method.getCoordinates().replaceMethod(), slf4jFormatString, updatedStringFormatArgument);
 
                 // In case of logger.log(Level.INFO, "Hello {0}, {0}", "foo")

--- a/src/test/java/org/openrewrite/java/logging/slf4j/JulParameterizedArgumentsTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/JulParameterizedArgumentsTest.java
@@ -62,6 +62,42 @@ class JulParameterizedArgumentsTest implements RewriteTest {
     }
 
     @Test
+    void escapeCharacters() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import java.util.logging.Level;
+              import java.util.logging.Logger;
+
+              class Test {
+                  void method(Logger logger, String param1) {
+                      logger.log(Level.INFO, "page:\\fnext:{0}", param1);
+                      logger.log(Level.INFO, "bell:\\bend:{0}", param1);
+                      logger.log(Level.INFO, "path C:\\\\temp {0}", param1);
+                      logger.log(Level.INFO, "say \\"{0}\\"", param1);
+                      logger.log(Level.INFO, "a\\nb\\tc\\"d {0}", param1);
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+
+              class Test {
+                  void method(Logger logger, String param1) {
+                      logger.info("page:\\fnext:{}", param1);
+                      logger.info("bell:\\bend:{}", param1);
+                      logger.info("path C:\\\\temp {}", param1);
+                      logger.info("say \\"{}\\"", param1);
+                      logger.info("a\\nb\\tc\\"d {}", param1);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void parameterizedArgumentArray() {
         rewriteRun(
           // language=java

--- a/src/test/java/org/openrewrite/java/logging/slf4j/StringFormatToParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/StringFormatToParameterizedLoggingTest.java
@@ -166,6 +166,47 @@ class StringFormatToParameterizedLoggingTest implements RewriteTest {
     }
 
     @Test
+    void escapeCharacters() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.slf4j.Logger;
+              import org.slf4j.LoggerFactory;
+
+              class Test {
+                  private static final Logger LOGGER = LoggerFactory.getLogger(Test.class);
+
+                  void method(String username) {
+                      LOGGER.error(String.format("page:\\fnext:%s", username));
+                      LOGGER.error(String.format("bell:\\bend:%s", username));
+                      LOGGER.error(String.format("path C:\\\\temp %s", username));
+                      LOGGER.error(String.format("say \\"%s\\"", username));
+                      LOGGER.error(String.format("a\\nb\\tc\\"d %s", username));
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+              import org.slf4j.LoggerFactory;
+
+              class Test {
+                  private static final Logger LOGGER = LoggerFactory.getLogger(Test.class);
+
+                  void method(String username) {
+                      LOGGER.error("page:\\fnext:{}", username);
+                      LOGGER.error("bell:\\bend:{}", username);
+                      LOGGER.error("path C:\\\\temp {}", username);
+                      LOGGER.error("say \\"{}\\"", username);
+                      LOGGER.error("a\\nb\\tc\\"d {}", username);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotReplaceInvalidPatterns() {
         //language=java
         rewriteRun(


### PR DESCRIPTION
## What's changed?
When SLF4J logging recipes rebuild a Java string literal from a decoded value, escape sequences were only partially re-applied: `\` and `"` were re-escaped, but decoded control characters (`\b \t \n \f \r`) were emitted raw, producing invalid/unreadable source. Added a shared `JavaStringEscapes.escapeJavaStringContent` helper that re-escapes.

## What's your motivation?
`String.format("a\nb\t%s", x)` was being rewritten to source containing literal newlines/tabs, breaking compilation. The bug existed in `StringFormatToParameterizedLogging` and, identically, in `JulParameterizedArguments`.

## Anything in particular you'd like reviewers to focus on?
The escaping policy in `JavaStringEscapes`: it intentionally does *not* `\u`-escape printable non-ASCII (unlike commons-text `escapeJava`), to keep i18n log messages readable. Only control chars and `\`/`"` are escaped.

## Anyone you would like to review specifically?
@timtebeek

## Have you considered any alternatives or workarounds?
Considered `org.apache.commons.text.StringEscapeUtils.escapeJava`.