### PR TITLE
Allow StringFormatToParameterizedLogging to migrate format strings without specifiers.

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/slf4j/AbstractFormatToParameterizedLogging.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/AbstractFormatToParameterizedLogging.java
@@ -135,6 +135,9 @@ public abstract class AbstractFormatToParameterizedLogging extends Recipe {
                     if (binary.getOperator() == J.Binary.Type.Addition) {
                         String left = extractFormatString(binary.getLeft());
                         String right = extractFormatString(binary.getRight());
+                        if (left == null || right == null) {
+                            return null;
+                        }
                         return left + right;
                     }
                 }

--- a/src/main/java/org/openrewrite/java/logging/slf4j/StringFormatToParameterizedLogging.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/StringFormatToParameterizedLogging.java
@@ -51,11 +51,7 @@ public class StringFormatToParameterizedLogging extends AbstractFormatToParamete
 
     @Override
     protected boolean isValidFormatString(String format) {
-        if (COMPLEX_FORMAT_PATTERN.matcher(format).find()) {
-            return false;
-        }
-
-        return SIMPLE_FORMAT_SPECIFIER.matcher(format).find();
+        return !COMPLEX_FORMAT_PATTERN.matcher(format).find();
     }
 
     @Override

--- a/src/test/java/org/openrewrite/java/logging/slf4j/StringFormatToParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/StringFormatToParameterizedLoggingTest.java
@@ -71,6 +71,8 @@ class StringFormatToParameterizedLoggingTest implements RewriteTest {
                       LOGGER.info(String.format("Boolean: %b", true));
                       LOGGER.info(String.format("Char: %c", 'x'));
 
+                      LOGGER.info(String.format("Just a plain message"));
+
                       LOGGER.info(MARKER, String.format("Message %s", message));
                       LOGGER.error(String.format("Failed: %s", message), exception);
                       LOGGER.error(MARKER, String.format("Failed: %s", message), exception);
@@ -116,6 +118,8 @@ class StringFormatToParameterizedLoggingTest implements RewriteTest {
                       LOGGER.info("Float: {}", value);
                       LOGGER.info("Boolean: {}", true);
                       LOGGER.info("Char: {}", 'x');
+
+                      LOGGER.info("Just a plain message");
 
                       LOGGER.info(MARKER, "Message {}", message);
                       LOGGER.error("Failed: {}", message, exception);

--- a/src/test/java/org/openrewrite/java/logging/slf4j/StringFormatToParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/StringFormatToParameterizedLoggingTest.java
@@ -228,6 +228,7 @@ class StringFormatToParameterizedLoggingTest implements RewriteTest {
                       LOGGER.info(String.format("Order: %2$s %1$s", first, second));
                       LOGGER.info(String.format("Complete: 100%%"));
                       LOGGER.info(String.format("Line1%nLine2"));
+                      LOGGER.info(String.format(first + " completed"));
                   }
               }
               """


### PR DESCRIPTION
## What's changed?

I want OpenRewrite to convert `String.format()` calls in SLF4J logging statements even when the format string has no format specifiers.

For example:

```java
LOGGER.info(String.format("Just a plain message"));
```

now becomes:

```java
LOGGER.info("Just a plain message");
```

I was careful to still skip complex format strings such as width, precision, escaped percent, and newline patterns.

## What's your motivation?

A specifier-free `String.format()` call is unnecessary. The recipe already handles replacing safe `String.format()` usage with direct SLF4J logging arguments, so this extends that cleanup to the no-specifier case.

## Anything in particular you'd like reviewers to focus on?

Please check the validation flow: `isValidFormatString()` now accepts strings that do not contain complex format patterns, while `validateArgumentCount()` still ensures the number of provided arguments matches the number of simple specifiers.

## Anyone you would like to review specifically?

Probably @timtebeek?

## Have you considered any alternatives or workarounds?

I suppose converting `String.format("Just a plain message")` to `"Just a plain message"` could be a stand-alone recipe, but I only ran into this problem while working through a logger upgrade. If it were stand-alone, it would need to be included in the logger composite recipe anyway.