### PR TITLE
Renew log4j 1.x suppression through 2026-09-01

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2026-08-01Z">
+    <suppress until="2026-09-01Z">
         <notes><![CDATA[
             False positive. log4j:log4j 1.2.17 is a deliberate dependency of
             rewrite-logging-frameworks — the recipes reference Log4j 1.x types in order to


### PR DESCRIPTION
- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1139

This repo's single suppression block carried `until="2026-08-01Z"` and lapsed before the 2026-08-03 scan, so the six Log4j 1.x CRITICALs (CVE-2019-17571, CVE-2020-9493, CVE-2022-23302, CVE-2022-23305, CVE-2022-23307, CVE-2023-26464) reappeared in the report.

Nothing has changed about the rationale: `log4j:log4j` 1.2.17 is a deliberate dependency here so the recipes can reference Log4j 1.x types in order to detect and migrate legacy usage. It is not used as a logging backend and is not on any deployed runtime classpath.

Renewed to 2026-09-01 rather than made indefinite. The rationale arguably can never change — the dependency is intentional and permanent — but the underlying CVEs are real vulnerabilities in code we do ship on the recipe classpath, so this stays time-boxed to force periodic review. Happy to switch it to indefinite if you'd prefer to stop re-approving it monthly.

Validates with `xmllint`.