### PR TITLE
Support `setCause` and optional `setMessage` in `WrapExpensiveLogStatementsInConditionals`

### DIFF
--- a/src/main/java/org/openrewrite/java/logging/slf4j/Log4j1MdcGetContextToCopyOfContextMap.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/Log4j1MdcGetContextToCopyOfContextMap.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.logging.slf4j;
 
 import lombok.Getter;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -43,6 +44,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 import static org.openrewrite.Tree.randomId;
 
 public class Log4j1MdcGetContextToCopyOfContextMap extends Recipe {
@@ -82,22 +84,27 @@ public class Log4j1MdcGetContextToCopyOfContextMap extends Recipe {
             public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
                 // Delegate the rename to the stock ChangeMethodName while the receiver is still org.apache.log4j.MDC.
                 doAfterVisit(new ChangeMethodName(GET_CONTEXT_PATTERN, "getCopyOfContextMap", null, null).getVisitor());
-                // Pre-scan for declarations assigned the result in a later statement so visitVariableDeclarations can retype them.
+                // Pre-scan for declarations that receive the result, so the other visit methods can retype them
+                // and recognize a `return` of such a declaration.
                 Set<JavaType.Variable> assignedFromGetContext = new JavaIsoVisitor<Set<JavaType.Variable>>() {
                     @Override
                     public J.Assignment visitAssignment(J.Assignment assignment, Set<JavaType.Variable> targets) {
-                        if (assignment.getAssignment() instanceof J.MethodInvocation &&
-                            GET_CONTEXT.matches((J.MethodInvocation) assignment.getAssignment())) {
+                        if (isGetContext(assignment.getAssignment())) {
                             // The target is either a bare name (`v = ...`) or a field access (`this.f = ...`).
-                            J.Identifier name = assignment.getVariable() instanceof J.Identifier ?
-                                    (J.Identifier) assignment.getVariable() :
-                                    assignment.getVariable() instanceof J.FieldAccess ?
-                                            ((J.FieldAccess) assignment.getVariable()).getName() : null;
-                            if (name != null && name.getFieldType() != null) {
-                                targets.add(name.getFieldType());
+                            JavaType.Variable target = variableOf(assignment.getVariable());
+                            if (target != null) {
+                                targets.add(target);
                             }
                         }
                         return super.visitAssignment(assignment, targets);
+                    }
+
+                    @Override
+                    public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Set<JavaType.Variable> targets) {
+                        if (isGetContext(variable.getInitializer()) && variable.getVariableType() != null) {
+                            targets.add(variable.getVariableType());
+                        }
+                        return super.visitVariable(variable, targets);
                     }
                 }.reduce(cu, new HashSet<>());
                 getCursor().putMessage(ASSIGNED_TARGETS_KEY, assignedFromGetContext);
@@ -161,11 +168,13 @@ public class Log4j1MdcGetContextToCopyOfContextMap extends Recipe {
             }
 
             private boolean returnsGetContext(J.MethodDeclaration method) {
+                Set<JavaType.Variable> retypedTargets = getCursor().getNearestMessage(ASSIGNED_TARGETS_KEY, emptySet());
                 return method.getBody() != null && new JavaIsoVisitor<AtomicBoolean>() {
                     @Override
                     public J.Return visitReturn(J.Return r, AtomicBoolean f) {
-                        if (r.getExpression() instanceof J.MethodInvocation &&
-                            GET_CONTEXT.matches((J.MethodInvocation) r.getExpression())) {
+                        // Either the call itself, or a declaration that visitVariableDeclarations retypes to Map.
+                        JavaType.Variable returned = variableOf(r.getExpression());
+                        if (isGetContext(r.getExpression()) || returned != null && retypedTargets.contains(returned)) {
                             f.set(true);
                         }
                         return super.visitReturn(r, f);
@@ -201,18 +210,29 @@ public class Log4j1MdcGetContextToCopyOfContextMap extends Recipe {
             }
 
             private boolean retypeFromGetContext(J.VariableDeclarations mv) {
-                Set<JavaType.Variable> assignedTargets = getCursor().getNearestMessage(ASSIGNED_TARGETS_KEY);
+                Set<JavaType.Variable> assignedTargets = getCursor().getNearestMessage(ASSIGNED_TARGETS_KEY, emptySet());
                 for (J.VariableDeclarations.NamedVariable nv : mv.getVariables()) {
-                    boolean initializedFromGetContext = nv.getInitializer() instanceof J.MethodInvocation &&
-                            GET_CONTEXT.matches((J.MethodInvocation) nv.getInitializer());
-                    if (initializedFromGetContext ||
-                        (assignedTargets != null && assignedTargets.contains(nv.getVariableType()))) {
+                    if (assignedTargets.contains(nv.getVariableType())) {
                         return true;
                     }
                 }
                 return false;
             }
         });
+    }
+
+    private static boolean isGetContext(@Nullable Expression expression) {
+        return expression instanceof J.MethodInvocation && GET_CONTEXT.matches((J.MethodInvocation) expression);
+    }
+
+    /**
+     * The {@link JavaType.Variable} a bare name ({@code v}) or field access ({@code this.f}) resolves to.
+     */
+    private static JavaType.@Nullable Variable variableOf(@Nullable Expression expression) {
+        if (expression instanceof J.FieldAccess) {
+            expression = ((J.FieldAccess) expression).getName();
+        }
+        return expression instanceof J.Identifier ? ((J.Identifier) expression).getFieldType() : null;
     }
 
     /**

--- a/src/main/java/org/openrewrite/java/logging/slf4j/StringFormatToParameterizedLogging.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/StringFormatToParameterizedLogging.java
@@ -51,7 +51,8 @@ public class StringFormatToParameterizedLogging extends AbstractFormatToParamete
 
     @Override
     protected boolean isValidFormatString(String format) {
-        return !COMPLEX_FORMAT_PATTERN.matcher(format).find();
+        // A literal `{}` would turn into an SLF4J placeholder once the `String.format` wrapper is dropped
+        return !format.contains("{}") && !COMPLEX_FORMAT_PATTERN.matcher(format).find();
     }
 
     @Override

--- a/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
@@ -64,244 +64,226 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
+        boolean useSetMessage = "SET_MESSAGE".equals(messageMethod);
         return Preconditions.check(
                 or(new UsesMethod<>(infoMatcher), new UsesMethod<>(debugMatcher), new UsesMethod<>(traceMatcher)),
-                new OptimizeLogStatementsVisitor("SET_MESSAGE".equals(messageMethod)));
+                new JavaVisitor<ExecutionContext>() {
+
+                    final Set<UUID> visitedBlocks = new HashSet<>();
+
+                    @Override
+                    public J visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                        J j = super.visitCompilationUnit(cu, ctx);
+                        if (j != cu && !visitedBlocks.isEmpty()) {
+                            doAfterVisit(new MergeLogStatementsInCheck(visitedBlocks));
+                        }
+                        return j;
+                    }
+
+                    @Override
+                    public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                        J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+                        if (m.getSelect() != null &&
+                                (infoMatcher.matches(m) || debugMatcher.matches(m) || traceMatcher.matches(m)) &&
+                                !isInIfStatementWithLogLevelCheck(getCursor(), m) &&
+                                !isAlreadyUsingFluentApi(getCursor()) &&
+                                isAnyArgumentExpensive(m)) {
+
+                            // Check if we should use fluent API (SLF4J 2.0+) or if-statements (SLF4J 1.x)
+                            if (supportsFluentApi(m)) {
+                                return convertToFluentApi(m, ctx);
+                            }
+                            // Use the traditional if-statement approach for SLF4J 1.x
+                            J container = getCursor().getParentTreeCursor().getValue();
+                            if (container instanceof J.Block) {
+                                UUID id = container.getId();
+                                J.If if_ = ((J.If) JavaTemplate
+                                        .builder("if(#{logger:any(org.slf4j.Logger)}.is#{}Enabled()) {}")
+                                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "slf4j-api-1.+"))
+                                        .build()
+                                        .apply(getCursor(), m.getCoordinates().replace(),
+                                                m.getSelect(), StringUtils.capitalize(m.getSimpleName())))
+                                        .withThenPart(m.withPrefix(m.getPrefix().withWhitespace("\n" + m.getPrefix().getWhitespace().replace("\n", ""))))
+                                        .withPrefix(m.getPrefix().withComments(emptyList()));
+                                visitedBlocks.add(id);
+                                return if_;
+                            }
+                        }
+                        return m;
+                    }
+
+                    private J.MethodInvocation convertToFluentApi(J.MethodInvocation m, ExecutionContext ctx) {
+                        List<Expression> args = m.getArguments();
+                        if (args.isEmpty()) {
+                            return m;
+                        }
+
+                        Expression messageTemplate = args.get(0);
+                        boolean expensiveMessage = isExpensiveArgument(messageTemplate);
+                        int lastArgument = hasTrailingCause(args) ? args.size() - 1 : args.size();
+
+                        StringBuilder templateStr = new StringBuilder();
+                        templateStr.append("#{logger:any(org.slf4j.Logger)}.at")
+                                .append(StringUtils.capitalize(m.getSimpleName())).append("()");
+                        List<Object> templateArgs = new ArrayList<>();
+                        //noinspection DataFlowIssue
+                        templateArgs.add(m.getSelect());
+
+                        if (useSetMessage) {
+                            templateStr.append(expensiveMessage ? ".setMessage(() -> #{any()})" : ".setMessage(#{any()})");
+                            templateArgs.add(messageTemplate);
+                        }
+
+                        // Use a supplier lambda for expensive arguments, and the value itself for cheap ones
+                        for (int i = 1; i < lastArgument; i++) {
+                            Expression arg = args.get(i);
+                            templateStr.append(isExpensiveArgument(arg) ? ".addArgument(() -> #{any()})" : ".addArgument(#{any()})");
+                            templateArgs.add(arg);
+                        }
+                        if (lastArgument < args.size()) {
+                            templateStr.append(".setCause(#{any()})");
+                            templateArgs.add(args.get(args.size() - 1));
+                        }
+
+                        if (useSetMessage) {
+                            templateStr.append(".log()");
+                        } else {
+                            templateStr.append(expensiveMessage ? ".log(() -> #{any()})" : ".log(#{any()})");
+                            templateArgs.add(messageTemplate);
+                        }
+
+                        return JavaTemplate
+                                .builder(templateStr.toString())
+                                .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "slf4j-api-2.+"))
+                                .build()
+                                .apply(getCursor(), m.getCoordinates().replace(), templateArgs.toArray());
+                    }
+                });
     }
 
-
-private static class OptimizeLogStatementsVisitor extends JavaVisitor<ExecutionContext> {
-
-        final Set<UUID> visitedBlocks = new HashSet<>();
-        private final boolean useSetMessage;
-
-        private OptimizeLogStatementsVisitor(boolean useSetMessage) {
-            this.useSetMessage = useSetMessage;
-        }
-
-        private boolean supportsFluentApi(J.MethodInvocation logMethod) {
-            // Check if the logger type supports fluent API by looking for atInfo/atDebug/atTrace methods
-            if (logMethod.getSelect() == null || logMethod.getMethodType() == null) {
-                return false;
-            }
-
-            JavaType.FullyQualified loggerType = TypeUtils.asFullyQualified(logMethod.getMethodType().getDeclaringType());
-            if (loggerType == null) {
-                return false;
-            }
-
-            // Check if the logger type has the fluent API methods (introduced in SLF4J 2.0)
-            return loggerType.getMethods().stream()
-                    .anyMatch(m -> "atInfo".equals(m.getName()) ||
-                                  "atDebug".equals(m.getName()) ||
-                                  "atTrace".equals(m.getName()));
-        }
-
-        @Override
-        public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-            J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
-            if (m.getSelect() != null &&
-                    (infoMatcher.matches(m) || debugMatcher.matches(m) || traceMatcher.matches(m)) &&
-                    !isInIfStatementWithLogLevelCheck(getCursor(), m) &&
-                    !isAlreadyUsingFluentApi(getCursor()) &&
-                    isAnyArgumentExpensive(m)) {
-
-                // Check if we should use fluent API (SLF4J 2.0+) or if-statements (SLF4J 1.x)
-                if (supportsFluentApi(m)) {
-                    return convertToFluentApi(m, ctx);
-                }
-                // Use the traditional if-statement approach for SLF4J 1.x
-                J container = getCursor().getParentTreeCursor().getValue();
-                if (container instanceof J.Block) {
-                    UUID id = container.getId();
-                    J.If if_ = ((J.If) JavaTemplate
-                            .builder("if(#{logger:any(org.slf4j.Logger)}.is#{}Enabled()) {}")
-                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "slf4j-api-1.+"))
-                            .build()
-                            .apply(getCursor(), m.getCoordinates().replace(),
-                                    m.getSelect(), StringUtils.capitalize(m.getSimpleName())))
-                            .withThenPart(m.withPrefix(m.getPrefix().withWhitespace("\n" + m.getPrefix().getWhitespace().replace("\n", ""))))
-                            .withPrefix(m.getPrefix().withComments(emptyList()));
-                    visitedBlocks.add(id);
-                    return if_;
-                }
-            }
-            return m;
-        }
-
-        private J.MethodInvocation convertToFluentApi(J.MethodInvocation m, ExecutionContext ctx) {
-            String logLevel = m.getSimpleName();
-            String fluentLevel = "at" + StringUtils.capitalize(logLevel);
-
-            List<Expression> args = m.getArguments();
-            if (args.isEmpty()) {
-                return m;
-            }
-
-            Expression messageTemplate = args.get(0);
-            boolean expensiveMessage = isExpensiveArgument(messageTemplate);
-            int lastArgument = hasTrailingCause(args) ? args.size() - 1 : args.size();
-
-            StringBuilder templateStr = new StringBuilder();
-            templateStr.append("#{logger:any(org.slf4j.Logger)}.").append(fluentLevel).append("()");
-            List<Object> templateArgs = new ArrayList<>();
-            //noinspection DataFlowIssue
-            templateArgs.add(m.getSelect());
-
-            if (useSetMessage) {
-                templateStr.append(expensiveMessage ? ".setMessage(() -> #{any()})" : ".setMessage(#{any()})");
-                templateArgs.add(messageTemplate);
-            }
-
-            // Use a supplier lambda for expensive arguments, and the value itself for cheap ones
-            for (int i = 1; i < lastArgument; i++) {
-                Expression arg = args.get(i);
-                templateStr.append(isExpensiveArgument(arg) ? ".addArgument(() -> #{any()})" : ".addArgument(#{any()})");
-                templateArgs.add(arg);
-            }
-            if (lastArgument < args.size()) {
-                templateStr.append(".setCause(#{any()})");
-                templateArgs.add(args.get(args.size() - 1));
-            }
-
-            if (useSetMessage) {
-                templateStr.append(".log()");
-            } else {
-                templateStr.append(expensiveMessage ? ".log(() -> #{any()})" : ".log(#{any()})");
-                templateArgs.add(messageTemplate);
-            }
-
-            return JavaTemplate
-                    .builder(templateStr.toString())
-                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "slf4j-api-2.+"))
-                    .build()
-                    .apply(getCursor(), m.getCoordinates().replace(), templateArgs.toArray());
-        }
-
-        /**
-         * SLF4J only treats a trailing {@link Throwable} as the cause when it is not consumed by a placeholder.
-         */
-        private boolean hasTrailingCause(List<Expression> args) {
-            if (args.size() < 2 || !TypeUtils.isAssignableTo("java.lang.Throwable", args.get(args.size() - 1).getType())) {
-                return false;
-            }
-            Object message = args.get(0) instanceof J.Literal ? ((J.Literal) args.get(0)).getValue() : null;
-            return message instanceof String && countPlaceholders((String) message) <= args.size() - 2;
-        }
-
-        private int countPlaceholders(String message) {
-            int count = 0;
-            for (int i = message.indexOf("{}"); i != -1; i = message.indexOf("{}", i + 2)) {
-                // Only an odd number of preceding backslashes escapes the placeholder
-                int backslashes = 0;
-                for (int j = i - 1; j >= 0 && message.charAt(j) == '\\'; j--) {
-                    backslashes++;
-                }
-                if (backslashes % 2 == 0) {
-                    count++;
-                }
-            }
-            return count;
-        }
-
-        private boolean isExpensiveArgument(Expression arg) {
-            return !(arg instanceof J.MethodInvocation && isSimpleGetter((J.MethodInvocation) arg) ||
-                    arg instanceof J.Literal ||
-                    arg instanceof J.Identifier ||
-                    arg instanceof J.FieldAccess ||
-                    arg instanceof J.Binary && isOnlyLiterals((J.Binary) arg));
-        }
-
-        private boolean isAlreadyUsingFluentApi(Cursor cursor) {
-            // Check if we're already in a fluent API chain
-            J.MethodInvocation parent = cursor.firstEnclosing(J.MethodInvocation.class);
-            if (parent != null && "log".equals(parent.getSimpleName())) {
-                Expression select = parent.getSelect();
-                if (select instanceof J.MethodInvocation) {
-                    J.MethodInvocation selectMethod = (J.MethodInvocation) select;
-                    return "addArgument".equals(selectMethod.getSimpleName()) ||
-                           "addParameter".equals(selectMethod.getSimpleName()) ||
-                           selectMethod.getSimpleName().startsWith("at");
-                }
-            }
+    private static boolean supportsFluentApi(J.MethodInvocation logMethod) {
+        // Check if the logger type supports fluent API by looking for atInfo/atDebug/atTrace methods
+        if (logMethod.getSelect() == null || logMethod.getMethodType() == null) {
             return false;
         }
 
-        @Override
-        public J visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
-            J j = super.visitCompilationUnit(cu, ctx);
-            if (j != cu && !visitedBlocks.isEmpty()) {
-                doAfterVisit(new MergeLogStatementsInCheck(visitedBlocks));
-            }
-            return j;
-        }
-
-        private boolean isInIfStatementWithLogLevelCheck(Cursor cursor, J.MethodInvocation m) {
-            J.If enclosingIf = cursor.firstEnclosing(J.If.class);
-            if (enclosingIf == null) {
-                return false;
-            }
-            List<J> sideEffects = enclosingIf.getIfCondition().getSideEffects();
-            return (infoMatcher.matches(m) && sideEffects.stream().allMatch(e -> e instanceof J.MethodInvocation && isInfoEnabledMatcher.matches((J.MethodInvocation) e))) ||
-                    (debugMatcher.matches(m) && sideEffects.stream().allMatch(e -> e instanceof J.MethodInvocation && isDebugEnabledMatcher.matches((J.MethodInvocation) e))) ||
-                    (traceMatcher.matches(m) && sideEffects.stream().allMatch(e -> e instanceof J.MethodInvocation && isTraceEnabledMatcher.matches((J.MethodInvocation) e)));
-        }
-
-        private boolean isAnyArgumentExpensive(J.MethodInvocation m) {
-            return m
-                    .getArguments()
-                    .stream()
-                    .anyMatch(arg ->
-                            !(arg instanceof J.MethodInvocation && isSimpleGetter((J.MethodInvocation) arg) ||
-                                    arg instanceof J.Literal ||
-                                    arg instanceof J.Identifier ||
-                                    arg instanceof J.FieldAccess ||
-                                    arg instanceof J.Binary && isOnlyLiterals((J.Binary) arg))
-                    );
-        }
-
-        private static boolean isSimpleGetter(J.MethodInvocation mi) {
-            if (mi.getMethodType() == null ||
-                    !mi.getMethodType().getParameterNames().isEmpty() ||
-                    mi.getMethodType().hasFlags(Flag.Static) ||
-                    !(mi.getSelect() == null || mi.getSelect() instanceof J.Identifier)) {
-                return false;
-            }
-            // Consider it a simple getter if it follows getter naming convention
-            if ((mi.getSimpleName().startsWith("get") && mi.getSimpleName().length() > 3) ||
-                    (mi.getSimpleName().startsWith("is") && mi.getSimpleName().length() > 2)) {
-                return true;
-            }
-            // Also consider record component accessors as simple getters
-            return mi.getMethodType().getDeclaringType().getKind() == JavaType.FullyQualified.Kind.Record;
-        }
-
-        private static boolean isOnlyLiterals(J.Binary binary) {
-            return isLiteralOrBinary(binary.getLeft()) && isLiteralOrBinary(binary.getRight());
-        }
-
-        private static boolean isLiteralOrBinary(J expression) {
-            return expression instanceof J.Literal ||
-                    isSimpleBooleanGetter(expression) ||
-                    isBooleanIdentifier(expression) ||
-                    expression instanceof J.Binary && isOnlyLiterals((J.Binary) expression);
-        }
-
-        private static boolean isSimpleBooleanGetter(J expression) {
-            if (expression instanceof J.MethodInvocation) {
-                J.MethodInvocation mi = (J.MethodInvocation) expression;
-                return isSimpleGetter(mi) && mi.getMethodType() != null && isTypeBoolean(mi.getMethodType().getReturnType());
-            }
+        JavaType.FullyQualified loggerType = TypeUtils.asFullyQualified(logMethod.getMethodType().getDeclaringType());
+        if (loggerType == null) {
             return false;
         }
 
-        private static boolean isBooleanIdentifier(J expression) {
-            return expression instanceof J.Identifier && isTypeBoolean(((J.Identifier) expression).getType());
-        }
+        // Check if the logger type has the fluent API methods (introduced in SLF4J 2.0)
+        return loggerType.getMethods().stream()
+                .anyMatch(m -> "atInfo".equals(m.getName()) ||
+                              "atDebug".equals(m.getName()) ||
+                              "atTrace".equals(m.getName()));
+    }
 
-        private static boolean isTypeBoolean(@Nullable JavaType type) {
-            return type == JavaType.Primitive.Boolean || TypeUtils.isAssignableTo("java.lang.Boolean", type);
+    /**
+     * SLF4J only treats a trailing {@link Throwable} as the cause when it is not consumed by a placeholder.
+     */
+    private static boolean hasTrailingCause(List<Expression> args) {
+        if (args.size() < 2 || !TypeUtils.isAssignableTo("java.lang.Throwable", args.get(args.size() - 1).getType())) {
+            return false;
         }
+        Object message = args.get(0) instanceof J.Literal ? ((J.Literal) args.get(0)).getValue() : null;
+        return message instanceof String && countPlaceholders((String) message) <= args.size() - 2;
+    }
+
+    private static int countPlaceholders(String message) {
+        int count = 0;
+        for (int i = message.indexOf("{}"); i != -1; i = message.indexOf("{}", i + 2)) {
+            // Only an odd number of preceding backslashes escapes the placeholder
+            int backslashes = 0;
+            for (int j = i - 1; j >= 0 && message.charAt(j) == '\\'; j--) {
+                backslashes++;
+            }
+            if (backslashes % 2 == 0) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static boolean isAlreadyUsingFluentApi(Cursor cursor) {
+        // Check if we're already in a fluent API chain
+        J.MethodInvocation parent = cursor.firstEnclosing(J.MethodInvocation.class);
+        if (parent != null && "log".equals(parent.getSimpleName())) {
+            Expression select = parent.getSelect();
+            if (select instanceof J.MethodInvocation) {
+                J.MethodInvocation selectMethod = (J.MethodInvocation) select;
+                return "addArgument".equals(selectMethod.getSimpleName()) ||
+                       "addParameter".equals(selectMethod.getSimpleName()) ||
+                       selectMethod.getSimpleName().startsWith("at");
+            }
+        }
+        return false;
+    }
+
+    private static boolean isInIfStatementWithLogLevelCheck(Cursor cursor, J.MethodInvocation m) {
+        J.If enclosingIf = cursor.firstEnclosing(J.If.class);
+        if (enclosingIf == null) {
+            return false;
+        }
+        List<J> sideEffects = enclosingIf.getIfCondition().getSideEffects();
+        return (infoMatcher.matches(m) && sideEffects.stream().allMatch(e -> e instanceof J.MethodInvocation && isInfoEnabledMatcher.matches((J.MethodInvocation) e))) ||
+                (debugMatcher.matches(m) && sideEffects.stream().allMatch(e -> e instanceof J.MethodInvocation && isDebugEnabledMatcher.matches((J.MethodInvocation) e))) ||
+                (traceMatcher.matches(m) && sideEffects.stream().allMatch(e -> e instanceof J.MethodInvocation && isTraceEnabledMatcher.matches((J.MethodInvocation) e)));
+    }
+
+    private static boolean isAnyArgumentExpensive(J.MethodInvocation m) {
+        return m.getArguments().stream().anyMatch(WrapExpensiveLogStatementsInConditionals::isExpensiveArgument);
+    }
+
+    private static boolean isExpensiveArgument(Expression arg) {
+        return !(arg instanceof J.MethodInvocation && isSimpleGetter((J.MethodInvocation) arg) ||
+                arg instanceof J.Literal ||
+                arg instanceof J.Identifier ||
+                arg instanceof J.FieldAccess ||
+                arg instanceof J.Binary && isOnlyLiterals((J.Binary) arg));
+    }
+
+    private static boolean isSimpleGetter(J.MethodInvocation mi) {
+        if (mi.getMethodType() == null ||
+                !mi.getMethodType().getParameterNames().isEmpty() ||
+                mi.getMethodType().hasFlags(Flag.Static) ||
+                !(mi.getSelect() == null || mi.getSelect() instanceof J.Identifier)) {
+            return false;
+        }
+        // Consider it a simple getter if it follows getter naming convention
+        if ((mi.getSimpleName().startsWith("get") && mi.getSimpleName().length() > 3) ||
+                (mi.getSimpleName().startsWith("is") && mi.getSimpleName().length() > 2)) {
+            return true;
+        }
+        // Also consider record component accessors as simple getters
+        return mi.getMethodType().getDeclaringType().getKind() == JavaType.FullyQualified.Kind.Record;
+    }
+
+    private static boolean isOnlyLiterals(J.Binary binary) {
+        return isLiteralOrBinary(binary.getLeft()) && isLiteralOrBinary(binary.getRight());
+    }
+
+    private static boolean isLiteralOrBinary(J expression) {
+        return expression instanceof J.Literal ||
+                isSimpleBooleanGetter(expression) ||
+                isBooleanIdentifier(expression) ||
+                expression instanceof J.Binary && isOnlyLiterals((J.Binary) expression);
+    }
+
+    private static boolean isSimpleBooleanGetter(J expression) {
+        if (expression instanceof J.MethodInvocation) {
+            J.MethodInvocation mi = (J.MethodInvocation) expression;
+            return isSimpleGetter(mi) && mi.getMethodType() != null && isTypeBoolean(mi.getMethodType().getReturnType());
+        }
+        return false;
+    }
+
+    private static boolean isBooleanIdentifier(J expression) {
+        return expression instanceof J.Identifier && isTypeBoolean(((J.Identifier) expression).getType());
+    }
+
+    private static boolean isTypeBoolean(@Nullable JavaType type) {
+        return type == JavaType.Primitive.Boolean || TypeUtils.isAssignableTo("java.lang.Boolean", type);
     }
 
     @EqualsAndHashCode(callSuper = false)

--- a/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
@@ -53,18 +53,20 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
             "This recipe optimizes these statements by either wrapping them in if-statements (SLF4J 1.x) " +
             "or converting them to fluent API calls (SLF4J 2.0+) to ensure expensive methods are only called when necessary.";
 
-    @Option(displayName = "Use `setMessage`",
-            description = "Pass the message template to `setMessage(..)` ahead of the arguments, instead of to `log(..)` " +
-                          "after the arguments, when converting to the SLF4J 2.0+ fluent API. Defaults to `false`.",
+    @Option(displayName = "Message method",
+            description = "The SLF4J 2.0+ fluent API method that takes the message template: `SET_MESSAGE` passes it to " +
+                          "`setMessage(..)` ahead of the arguments, `LOG` passes it to `log(..)` after the arguments. " +
+                          "Defaults to `LOG`.",
+            valid = {"SET_MESSAGE", "LOG"},
             required = false)
     @Nullable
-    Boolean useSetMessage;
+    String messageMethod;
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
                 or(new UsesMethod<>(infoMatcher), new UsesMethod<>(debugMatcher), new UsesMethod<>(traceMatcher)),
-                new OptimizeLogStatementsVisitor(Boolean.TRUE.equals(useSetMessage)));
+                new OptimizeLogStatementsVisitor("SET_MESSAGE".equals(messageMethod)));
     }
 
 
@@ -137,7 +139,7 @@ private static class OptimizeLogStatementsVisitor extends JavaVisitor<ExecutionC
             }
 
             Expression messageTemplate = args.get(0);
-            boolean expensiveMessage = args.size() == 1 && isExpensiveArgument(messageTemplate);
+            boolean expensiveMessage = isExpensiveArgument(messageTemplate);
             int lastArgument = hasTrailingCause(args) ? args.size() - 1 : args.size();
 
             StringBuilder templateStr = new StringBuilder();
@@ -190,7 +192,12 @@ private static class OptimizeLogStatementsVisitor extends JavaVisitor<ExecutionC
         private int countPlaceholders(String message) {
             int count = 0;
             for (int i = message.indexOf("{}"); i != -1; i = message.indexOf("{}", i + 2)) {
-                if (i == 0 || message.charAt(i - 1) != '\\') {
+                // Only an odd number of preceding backslashes escapes the placeholder
+                int backslashes = 0;
+                for (int j = i - 1; j >= 0 && message.charAt(j) == '\\'; j--) {
+                    backslashes++;
+                }
+                if (backslashes % 2 == 0) {
                     count++;
                 }
             }

--- a/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
+++ b/src/main/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionals.java
@@ -16,7 +16,6 @@
 package org.openrewrite.java.logging.slf4j;
 
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
@@ -34,6 +33,8 @@ import static java.util.stream.Collectors.toList;
 import static org.openrewrite.Preconditions.or;
 import static org.openrewrite.Tree.randomId;
 
+@EqualsAndHashCode(callSuper = false)
+@Value
 public class WrapExpensiveLogStatementsInConditionals extends Recipe {
 
     // Only matching up to INFO, as WARN and ERROR are rarely disabled
@@ -45,26 +46,36 @@ public class WrapExpensiveLogStatementsInConditionals extends Recipe {
     private static final MethodMatcher isDebugEnabledMatcher = new MethodMatcher("org.slf4j.Logger isDebugEnabled()");
     private static final MethodMatcher isTraceEnabledMatcher = new MethodMatcher("org.slf4j.Logger isTraceEnabled()");
 
-    @Getter
-    final String displayName = "Optimize log statements";
+    String displayName = "Optimize log statements";
 
-    @Getter
-    final String description = "When trace, debug and info log statements use methods for constructing log messages, " +
+    String description = "When trace, debug and info log statements use methods for constructing log messages, " +
             "those methods are called regardless of whether the log level is enabled. " +
             "This recipe optimizes these statements by either wrapping them in if-statements (SLF4J 1.x) " +
             "or converting them to fluent API calls (SLF4J 2.0+) to ensure expensive methods are only called when necessary.";
+
+    @Option(displayName = "Use `setMessage`",
+            description = "Pass the message template to `setMessage(..)` ahead of the arguments, instead of to `log(..)` " +
+                          "after the arguments, when converting to the SLF4J 2.0+ fluent API. Defaults to `false`.",
+            required = false)
+    @Nullable
+    Boolean useSetMessage;
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
                 or(new UsesMethod<>(infoMatcher), new UsesMethod<>(debugMatcher), new UsesMethod<>(traceMatcher)),
-                new OptimizeLogStatementsVisitor());
+                new OptimizeLogStatementsVisitor(Boolean.TRUE.equals(useSetMessage)));
     }
 
 
 private static class OptimizeLogStatementsVisitor extends JavaVisitor<ExecutionContext> {
 
         final Set<UUID> visitedBlocks = new HashSet<>();
+        private final boolean useSetMessage;
+
+        private OptimizeLogStatementsVisitor(boolean useSetMessage) {
+            this.useSetMessage = useSetMessage;
+        }
 
         private boolean supportsFluentApi(J.MethodInvocation logMethod) {
             // Check if the logger type supports fluent API by looking for atInfo/atDebug/atTrace methods
@@ -121,66 +132,69 @@ private static class OptimizeLogStatementsVisitor extends JavaVisitor<ExecutionC
             String fluentLevel = "at" + StringUtils.capitalize(logLevel);
 
             List<Expression> args = m.getArguments();
-            if (!args.isEmpty()) {
-                if (args.size() > 1) {
-                    // First argument is the message template
-                    Expression messageTemplate = args.get(0);
-
-                    // Build fluent API with addArgument() calls for each parameter
-                    StringBuilder templateStr = new StringBuilder();
-                    templateStr.append("#{logger:any(org.slf4j.Logger)}.").append(fluentLevel).append("()");
-
-                    // Add each parameter as an argument
-                    // Use lambda for expensive operations, direct value for cheap ones
-                    List<Object> templateArgs = new ArrayList<>();
-                    //noinspection DataFlowIssue
-                    templateArgs.add(m.getSelect());
-
-                    for (int i = 1; i < args.size(); i++) {
-                        Expression arg = args.get(i);
-                        if (isExpensiveArgument(arg)) {
-                            // Use supplier lambda for expensive operations
-                            templateStr.append(".addArgument(() -> #{any()})");
-                        } else {
-                            // Use direct value for cheap operations
-                            templateStr.append(".addArgument(#{any()})");
-                        }
-                        templateArgs.add(arg);
-                    }
-                    templateStr.append(".log(#{any()})");
-                    templateArgs.add(messageTemplate);
-
-                    JavaTemplate template = JavaTemplate
-                            .builder(templateStr.toString())
-                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "slf4j-api-2.+"))
-                            .build();
-
-                    return template.apply(getCursor(), m.getCoordinates().replace(), templateArgs.toArray());
-                }
-                // Simple case with just a message
-                Expression arg = args.get(0);
-                if (isExpensiveArgument(arg)) {
-                    // Use supplier lambda for expensive message
-                    JavaTemplate template = JavaTemplate
-                            .builder("#{logger:any(org.slf4j.Logger)}.#{}().log(() -> #{any()})")
-                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "slf4j-api-2.+"))
-                            .build();
-
-                    //noinspection DataFlowIssue
-                    return template.apply(getCursor(), m.getCoordinates().replace(),
-                            m.getSelect(), fluentLevel, arg);
-                }
-                // Use direct value for cheap message
-                JavaTemplate template = JavaTemplate
-                        .builder("#{logger:any(org.slf4j.Logger)}.#{}().log(#{any()})")
-                        .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "slf4j-api-2.+"))
-                        .build();
-
-                //noinspection DataFlowIssue
-                return template.apply(getCursor(), m.getCoordinates().replace(),
-                        m.getSelect(), fluentLevel, arg);
+            if (args.isEmpty()) {
+                return m;
             }
-            return m;
+
+            Expression messageTemplate = args.get(0);
+            boolean expensiveMessage = args.size() == 1 && isExpensiveArgument(messageTemplate);
+            int lastArgument = hasTrailingCause(args) ? args.size() - 1 : args.size();
+
+            StringBuilder templateStr = new StringBuilder();
+            templateStr.append("#{logger:any(org.slf4j.Logger)}.").append(fluentLevel).append("()");
+            List<Object> templateArgs = new ArrayList<>();
+            //noinspection DataFlowIssue
+            templateArgs.add(m.getSelect());
+
+            if (useSetMessage) {
+                templateStr.append(expensiveMessage ? ".setMessage(() -> #{any()})" : ".setMessage(#{any()})");
+                templateArgs.add(messageTemplate);
+            }
+
+            // Use a supplier lambda for expensive arguments, and the value itself for cheap ones
+            for (int i = 1; i < lastArgument; i++) {
+                Expression arg = args.get(i);
+                templateStr.append(isExpensiveArgument(arg) ? ".addArgument(() -> #{any()})" : ".addArgument(#{any()})");
+                templateArgs.add(arg);
+            }
+            if (lastArgument < args.size()) {
+                templateStr.append(".setCause(#{any()})");
+                templateArgs.add(args.get(args.size() - 1));
+            }
+
+            if (useSetMessage) {
+                templateStr.append(".log()");
+            } else {
+                templateStr.append(expensiveMessage ? ".log(() -> #{any()})" : ".log(#{any()})");
+                templateArgs.add(messageTemplate);
+            }
+
+            return JavaTemplate
+                    .builder(templateStr.toString())
+                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "slf4j-api-2.+"))
+                    .build()
+                    .apply(getCursor(), m.getCoordinates().replace(), templateArgs.toArray());
+        }
+
+        /**
+         * SLF4J only treats a trailing {@link Throwable} as the cause when it is not consumed by a placeholder.
+         */
+        private boolean hasTrailingCause(List<Expression> args) {
+            if (args.size() < 2 || !TypeUtils.isAssignableTo("java.lang.Throwable", args.get(args.size() - 1).getType())) {
+                return false;
+            }
+            Object message = args.get(0) instanceof J.Literal ? ((J.Literal) args.get(0)).getValue() : null;
+            return message instanceof String && countPlaceholders((String) message) <= args.size() - 2;
+        }
+
+        private int countPlaceholders(String message) {
+            int count = 0;
+            for (int i = message.indexOf("{}"); i != -1; i = message.indexOf("{}", i + 2)) {
+                if (i == 0 || message.charAt(i - 1) != '\\') {
+                    count++;
+                }
+            }
+            return count;
         }
 
         private boolean isExpensiveArgument(Expression arg) {

--- a/src/test/java/org/openrewrite/java/logging/slf4j/Log4j1MdcGetContextToCopyOfContextMapTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/Log4j1MdcGetContextToCopyOfContextMapTest.java
@@ -99,6 +99,40 @@ class Log4j1MdcGetContextToCopyOfContextMapTest implements RewriteTest {
     }
 
     @Test
+    void retypeReturnTypeOfMethodReturningRetypedLocal() {
+        //language=java
+        rewriteRun(
+          java(
+            """
+              import org.apache.log4j.MDC;
+
+              import java.util.Hashtable;
+
+              class Test {
+                  Hashtable via() {
+                      Hashtable context = MDC.getContext();
+                      return context;
+                  }
+              }
+              """,
+            """
+              import org.apache.log4j.MDC;
+
+              import java.util.Hashtable;
+              import java.util.Map;
+
+              class Test {
+                  Map<String, String> via() {
+                      Map<String, String> context = MDC.getCopyOfContextMap();
+                      return context;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotReplaceInvalidPatterns() {
         //language=java
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/logging/slf4j/StringFormatToParameterizedLoggingTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/StringFormatToParameterizedLoggingTest.java
@@ -222,13 +222,14 @@ class StringFormatToParameterizedLoggingTest implements RewriteTest {
               class Test {
                   private static final Logger LOGGER = LoggerFactory.getLogger(Test.class);
 
-                  void method(double value, int number, String first, String second) {
+                  void method(double value, int number, String first, String second, Exception exception) {
                       LOGGER.info(String.format("Value: %.2f", value));
                       LOGGER.info(String.format("Width: %5d", number));
                       LOGGER.info(String.format("Order: %2$s %1$s", first, second));
                       LOGGER.info(String.format("Complete: 100%%"));
                       LOGGER.info(String.format("Line1%nLine2"));
                       LOGGER.info(String.format(first + " completed"));
+                      LOGGER.error(String.format("Response body: {}"), exception);
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionalsSlf4j2Test.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionalsSlf4j2Test.java
@@ -287,9 +287,45 @@ class WrapExpensiveLogStatementsInConditionalsSlf4j2Test implements RewriteTest 
     }
 
     @Test
+    void expensiveMessageAlongsideArgumentsIsSupplied() {
+        rewriteRun(
+          java(
+            """
+              import org.slf4j.Logger;
+
+              class A {
+                  void method(Logger logger, Exception e, String value) {
+                      logger.debug(buildMessage(), value);
+                      logger.debug(buildMessage(), e);
+                  }
+
+                  String buildMessage() {
+                      return "message" + hashCode();
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+
+              class A {
+                  void method(Logger logger, Exception e, String value) {
+                      logger.atDebug().addArgument(value).log(() -> buildMessage());
+                      logger.atDebug().addArgument(e).log(() -> buildMessage());
+                  }
+
+                  String buildMessage() {
+                      return "message" + hashCode();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void useSetMessage() {
         rewriteRun(
-          spec -> spec.recipe(new WrapExpensiveLogStatementsInConditionals(true)),
+          spec -> spec.recipe(new WrapExpensiveLogStatementsInConditionals("SET_MESSAGE")),
           java(
             """
               import org.slf4j.Logger;
@@ -299,6 +335,7 @@ class WrapExpensiveLogStatementsInConditionalsSlf4j2Test implements RewriteTest 
                       logger.debug("Value was {}", computeValue());
                       logger.debug("An error occurred while processing value {}", computeValue(), e);
                       logger.info(expensiveOp());
+                      logger.info(expensiveOp(), computeValue());
                   }
 
                   String computeValue() {
@@ -318,6 +355,7 @@ class WrapExpensiveLogStatementsInConditionalsSlf4j2Test implements RewriteTest 
                       logger.atDebug().setMessage("Value was {}").addArgument(() -> computeValue()).log();
                       logger.atDebug().setMessage("An error occurred while processing value {}").addArgument(() -> computeValue()).setCause(e).log();
                       logger.atInfo().setMessage(() -> expensiveOp()).log();
+                      logger.atInfo().setMessage(() -> expensiveOp()).addArgument(() -> computeValue()).log();
                   }
 
                   String computeValue() {

--- a/src/test/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionalsSlf4j2Test.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionalsSlf4j2Test.java
@@ -30,7 +30,7 @@ class WrapExpensiveLogStatementsInConditionalsSlf4j2Test implements RewriteTest 
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new WrapExpensiveLogStatementsInConditionals())
+        spec.recipe(new WrapExpensiveLogStatementsInConditionals(null))
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(), "slf4j-api-2"));
     }
@@ -211,6 +211,121 @@ class WrapExpensiveLogStatementsInConditionalsSlf4j2Test implements RewriteTest 
 
                   String computeValue() {
                       return "value";
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void setCauseForTrailingThrowable() {
+        rewriteRun(
+          java(
+            """
+              import org.slf4j.Logger;
+
+              class A {
+                  void method(Logger logger, Exception e) {
+                      logger.debug("An error occurred while processing value {}", computeValue(), e);
+                  }
+
+                  String computeValue() {
+                      return "value" + hashCode();
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+
+              class A {
+                  void method(Logger logger, Exception e) {
+                      logger.atDebug().addArgument(() -> computeValue()).setCause(e).log("An error occurred while processing value {}");
+                  }
+
+                  String computeValue() {
+                      return "value" + hashCode();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void keepThrowableAsArgumentWhenConsumedByPlaceholder() {
+        rewriteRun(
+          java(
+            """
+              import org.slf4j.Logger;
+
+              class A {
+                  void method(Logger logger, Exception e) {
+                      logger.debug("Processing {} failed with {}", computeValue(), e);
+                  }
+
+                  String computeValue() {
+                      return "value" + hashCode();
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+
+              class A {
+                  void method(Logger logger, Exception e) {
+                      logger.atDebug().addArgument(() -> computeValue()).addArgument(e).log("Processing {} failed with {}");
+                  }
+
+                  String computeValue() {
+                      return "value" + hashCode();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void useSetMessage() {
+        rewriteRun(
+          spec -> spec.recipe(new WrapExpensiveLogStatementsInConditionals(true)),
+          java(
+            """
+              import org.slf4j.Logger;
+
+              class A {
+                  void method(Logger logger, Exception e) {
+                      logger.debug("Value was {}", computeValue());
+                      logger.debug("An error occurred while processing value {}", computeValue(), e);
+                      logger.info(expensiveOp());
+                  }
+
+                  String computeValue() {
+                      return "value" + hashCode();
+                  }
+
+                  String expensiveOp() {
+                      return "expensive" + hashCode();
+                  }
+              }
+              """,
+            """
+              import org.slf4j.Logger;
+
+              class A {
+                  void method(Logger logger, Exception e) {
+                      logger.atDebug().setMessage("Value was {}").addArgument(() -> computeValue()).log();
+                      logger.atDebug().setMessage("An error occurred while processing value {}").addArgument(() -> computeValue()).setCause(e).log();
+                      logger.atInfo().setMessage(() -> expensiveOp()).log();
+                  }
+
+                  String computeValue() {
+                      return "value" + hashCode();
+                  }
+
+                  String expensiveOp() {
+                      return "expensive" + hashCode();
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionalsTest.java
+++ b/src/test/java/org/openrewrite/java/logging/slf4j/WrapExpensiveLogStatementsInConditionalsTest.java
@@ -31,7 +31,7 @@ class WrapExpensiveLogStatementsInConditionalsTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipe(new WrapExpensiveLogStatementsInConditionals())
+        spec.recipe(new WrapExpensiveLogStatementsInConditionals(null))
           .parser(JavaParser.fromJavaVersion()
             .classpathFromResources(new InMemoryExecutionContext(), "slf4j-api-1.7.+"));
     }


### PR DESCRIPTION
- Addresses the two requests from [this comment](https://github.com/openrewrite/rewrite-logging-frameworks/issues/67#issuecomment-5257697533) on #67.

When converting to the SLF4J 2.0+ fluent API, a trailing `Throwable` now becomes `setCause(..)` instead of `addArgument(..)`, but only when it is not consumed by a placeholder, matching how SLF4J itself resolves the cause; a non-literal message template stays conservative and keeps `addArgument(..)`. A new optional `useSetMessage` option (off by default) places the message template ahead of the arguments via `setMessage(..)` and calls `log()` with no arguments, using the `Supplier` overload when the message itself is expensive.

Making both changes was cheap because `convertToFluentApi` first collapsed from three near-duplicate `JavaTemplate` branches into a single builder. The recipe is now `@Value` to carry the option, so the two Java test call sites pass `null`; declarative YAML usage is unaffected as the option is `required = false`.